### PR TITLE
fix: Add support for query params in `RichTextLink` extension

### DIFF
--- a/src/extensions/rich-text/rich-text-link.ts
+++ b/src/extensions/rich-text/rich-text-link.ts
@@ -9,7 +9,7 @@ import type { LinkOptions } from '@tiptap/extension-link'
  *
  * @see https://stephenweiss.dev/regex-markdown-link
  */
-const inputRegex = /(?:^|\s)\[([^\]]*)?\]\(([A-Za-z0-9:/. -]+)(?:["“](.+)["”])?\)$/
+const inputRegex = /(?:^|\s)\[([^\]]*)?\]\(([A-Za-z0-9:/.-?]+)(?: ["“](.+)["”])?\)$/
 
 /**
  * The paste regex for Markdown links with title support, and multiple quotation marks (required
@@ -17,7 +17,7 @@ const inputRegex = /(?:^|\s)\[([^\]]*)?\]\(([A-Za-z0-9:/. -]+)(?:["“](.+)["”
  *
  * @see https://stephenweiss.dev/regex-markdown-link
  */
-const pasteRegex = /(?:^|\s)\[([^\]]*)?\]\(([A-Za-z0-9:/. -]+)(?:["“](.+)["”])?\)/g
+const pasteRegex = /(?:^|\s)\[([^\]]*)?\]\(([A-Za-z0-9:/.-?]+)(?: ["“](.+)["”])?\)/g
 
 /**
  * Input rule built specifically for the `Link` extension, which ignores the auto-linked URL in


### PR DESCRIPTION
## Overview

It was pointed out to me (by @scottlovegrove) that our `RichTextLink` extension doesn't support typing/pasting Markdown links with query parameters, and this PR takes care of that by adding `?` to the regular expression. It also moves the space character to the next non-capturing group because a space is not valid in a URL, but it's required right before the `"title"` in the Markdown link syntax.

I should also point out that the regular expression that we use in the `RichTextLink` extension does a basic validation of links ([ref](https://stephenweiss.dev/regex-markdown-link)), and that's why I simply added the `?` character without worrying too much about invalid links. Having a more complete regular expression to only accept valid links here would be a lot more complex and not really worth it.

## PR Checklist

- [ ] Changes introduced here have been manually tested by someone other than the PR author
- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Type the following in the editor: `[link](https://doist.dev?foo=bar)`
    - [x] Observe that as soon as you type `)` the **Markdown Output** shows `[link](https://doist.dev?foo=bar)`

While the regular expression for the paste rule was also changed similarly, this rule is currently bypassed because the `PasteMarkdown` extension is overriding all paste events. If you still want to test it out, follow this steps:

- Open the `rich-text-kit.ts`, and remove the `extensions.push(PasteMarkdown)` line
- Launch and open the local Storybook with `npm run storybook:start`
- Open the `Rich-text → Default` story
- Paste the following in the editor: `[link](https://doist.dev?foo=bar)` with <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>V</kbd> (or <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>V</kbd>)
    - [x] Observe that the **Markdown Output** shows `[link](https://doist.dev?foo=bar)`