### PR TITLE
build: Disable source maps for deployed Storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -39,6 +39,7 @@ module.exports = {
         return mergeConfig(config, {
             build: {
                 assetsDir: '.',
+                sourcemap: false,
             },
         })
     },


### PR DESCRIPTION
## Overview

With #5 Netlify builds started to fail due to a fatal error (probably to the newly added dependencies for Storybook):

> Reached heap limit Allocation failed - JavaScript heap out of memory

This looks like a Vite build issue ([ref](https://github.com/vitejs/vite/issues/2433)), and disabling source maps fixes the issue (for now at least). We don't really make use of source maps for the deployed Storybook, so I'm disabling them for the time being.