### PR TITLE
docs: Adds "Deploys-by-Netlify" badge to the Storybook homepage

### DIFF
--- a/.storybook/preview.style.css
+++ b/.storybook/preview.style.css
@@ -47,6 +47,11 @@ body,
     box-sizing: inherit;
 }
 
+.netlify-badge {
+    text-align: center;
+    margin-top: 3rem;
+}
+
 /*
  * Overwrite `github-markdown-css` style with custom styles.
  */

--- a/stories/readme.story.mdx
+++ b/stories/readme.story.mdx
@@ -15,3 +15,12 @@ import { MarkdownRenderer } from './components/markdown-renderer.tsx'
 />
 
 <MarkdownRenderer markdown={rawReadme} />
+
+<div class="netlify-badge">
+    <a href="https://www.netlify.com">
+        <img
+            src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg"
+            alt="Deploys by Netlify"
+        />
+    </a>
+</div>


### PR DESCRIPTION
## Overview

Add the missing "Deploys-by-Netlify" badge to the Storybook homepage (i.e. `README.md`) to be in full compliance with the Netlify [Open Source Plan Policy](https://www.netlify.com/legal/open-source-policy/).