### PR TITLE
fix: `insertMarkdownContent` didn't insert Markdown correctly in plain-text documents

### DIFF
--- a/src/extensions/core/extra-editor-commands/commands/insert-markdown-content.ts
+++ b/src/extensions/core/extra-editor-commands/commands/insert-markdown-content.ts
@@ -2,7 +2,6 @@ import { RawCommands } from '@tiptap/core'
 import { DOMParser } from 'prosemirror-model'
 
 import { parseHtmlToElement } from '../../../../helpers/dom'
-import { isPlainTextDocument } from '../../../../helpers/schema'
 import { createHTMLSerializer } from '../../../../serializers/html/html'
 
 import type { ParseOptions } from 'prosemirror-model'
@@ -39,9 +38,7 @@ function insertMarkdownContent(
         // Check if the transaction should be dispatched
         // ref: https://tiptap.dev/api/commands#dry-run-for-commands
         if (dispatch) {
-            const htmlContent = !isPlainTextDocument(editor.schema)
-                ? createHTMLSerializer(editor.schema).serialize(markdown)
-                : markdown
+            const htmlContent = createHTMLSerializer(editor.schema).serialize(markdown)
 
             // Inserts the HTML content into the editor while preserving the current selection
             tr.replaceSelection(


### PR DESCRIPTION
## Overview

I've noticed that the `insertMarkdownContent` command was not working properly for plain-text documents, and this PR fixes that.

## PR Checklist

-   [ ] Changes introduced here have been manually tested by someone other than the PR author
-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Plain-text → Functions → Commands` story
- Click the `insertMarkdownContent` button
    - [x] Observe that Markdown content is inserted correctly (check the demo below)

## Demo

| Before                      | After                      |
| --------------------------- | -------------------------- |
| ![image](https://user-images.githubusercontent.com/96476/201096857-fc49a26b-fd44-4991-bab3-6a85a2795df6.png) | ![image](https://user-images.githubusercontent.com/96476/201096909-9681ec1f-1e0f-4218-9c17-5d32503592e3.png) |

