### PR TITLE
ci: Pin tier 2 actions to the specific full-length commit hash

### DIFF
--- a/.github/workflows/check-semantic-pull-request.yml
+++ b/.github/workflows/check-semantic-pull-request.yml
@@ -18,4 +18,4 @@ jobs:
 
         steps:
             - name: Validate pull request title
-              uses: amannn/action-semantic-pull-request@v5
+              uses: amannn/action-semantic-pull-request@01d5fd8a8ebb9aafe902c40c53f0f4744f7381eb

--- a/.github/workflows/update-license-copyright-year.yml
+++ b/.github/workflows/update-license-copyright-year.yml
@@ -17,7 +17,7 @@ jobs:
                   token: ${{ secrets.GH_REPO_TOKEN }}
 
             - name: Update copyright year in LICENSE.md
-              uses: FantasticFiasco/action-update-license-year@v2
+              uses: FantasticFiasco/action-update-license-year@f3d1911d2a05b8a69fee1de4033b2847c347d911
               with:
                   token: ${{ secrets.GH_REPO_TOKEN }}
                   commitTitle: 'docs(LICENSE): Update copyright year(s)'


### PR DESCRIPTION
## Overview

As documented in Doist Handbook, Tier 2 actions should always be pinned to their specific full-length commit hash, and never to tags (which are immutable, thus posing security risks).