### PR TITLE
fix: Activate the link mark at its end based on the `autolink` option

### DIFF
--- a/src/extensions/rich-text/rich-text-link.ts
+++ b/src/extensions/rich-text/rich-text-link.ts
@@ -66,7 +66,9 @@ function linkPasteRule(config: Parameters<typeof markPasteRule>[0]) {
  * adds support for the `title` attribute.
  */
 const RichTextLink = Link.extend({
-    inclusive: false,
+    inclusive() {
+        return this.options.autolink
+    },
     addAttributes() {
         return {
             ...this.parent?.(),


### PR DESCRIPTION
## Overview

This PR configures the `inclusive` attribute for the `RichTextLink` extension exactly like the original Link extension ([ref](https://github.com/ueberdosis/tiptap/blob/22cccc7f5db7e166d206c9a8e0a0cda8823a0839/packages/extension-link/src/link.ts#L72-L74)), activating the link mark at its end based on the `autolink` option.

## PR Checklist

-   [ ] Changes introduced here have been manually tested by someone other than the PR author

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Type "before link after" into the editor
- Select the "link" text and click the `Insert Link` button in the toolbar
- Add some link, e.g., `https://doist.com`, and press `Enter`
- Place the cursor at the end of `link`, e.g., `before link| after`
- Type `abc`
    - [ ] Observe the linked `link` text became `linkabc`

## Demo

| Before                      | After                      |
| --------------------------- | -------------------------- |
| ![firefox_X6XlATFrmx](https://user-images.githubusercontent.com/96476/203597933-26a993d0-365e-4c93-bb55-8446f4682bbb.gif) | ![firefox_NtYr0SLipy](https://user-images.githubusercontent.com/96476/203598172-d08d11a0-6619-4c3f-956e-7b8edd0ca095.gif) |