### PR TITLE
Fix(docs): correct the render function name

### DIFF
--- a/stories/documentation/usage/extensions.md
+++ b/stories/documentation/usage/extensions.md
@@ -35,7 +35,7 @@ function TypistEditorContainer({ content }) {
             renderAriaLabel({ label }) {
                 return `Name: ${label}`
             },
-            popupRenderFn() {
+            dropdownRenderFn() {
                 return {
                     onStart(props) {},
                     onUpdate(props) {},


### PR DESCRIPTION
The function name is supposed to be dropdownRenderFn instead of popupRenderFn. 
Refer issue #47 for discussion on this.

## PR Checklist
-   [x] Added/updated documentation to Storybook or `README.md`