### PR TITLE
chore: Rename `class` to `className` (HTML in MDX is JSX)

### DIFF
--- a/stories/readme.story.mdx
+++ b/stories/readme.story.mdx
@@ -16,7 +16,7 @@ import { MarkdownRenderer } from './components/markdown-renderer.tsx'
 
 <MarkdownRenderer markdown={rawReadme} />
 
-<div class="netlify-badge">
+<div className="netlify-badge">
     <a href="https://www.netlify.com">
         <img
             src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg"


### PR DESCRIPTION
## Overview

As pointed out by @henningmu ([ref](https://github.com/Doist/typist/pull/10#discussion_r1039423856)), HTML in MDX is JSX, so `className` should be used instead of `class` (although it was working as expected with `class` anyway).