### PR TITLE
fix(rich-text-link): More lenient regex for input/paste rule

### DIFF
--- a/src/extensions/rich-text/rich-text-link.ts
+++ b/src/extensions/rich-text/rich-text-link.ts
@@ -6,18 +6,14 @@ import type { LinkOptions } from '@tiptap/extension-link'
 /**
  * The input regex for Markdown links with title support, and multiple quotation marks (required
  * in case the `Typography` extension is being included).
- *
- * @see https://stephenweiss.dev/regex-markdown-link
  */
-const inputRegex = /(?:^|\s)\[([^\]]*)?\]\(([A-Za-z0-9:/.-?]+)(?: ["“](.+)["”])?\)$/
+const inputRegex = /(?:^|\s)\[([^\]]*)?\]\((\S+)(?: ["“](.+)["”])?\)$/i
 
 /**
  * The paste regex for Markdown links with title support, and multiple quotation marks (required
  * in case the `Typography` extension is being included).
- *
- * @see https://stephenweiss.dev/regex-markdown-link
  */
-const pasteRegex = /(?:^|\s)\[([^\]]*)?\]\(([A-Za-z0-9:/.-?]+)(?: ["“](.+)["”])?\)/g
+const pasteRegex = /(?:^|\s)\[([^\]]*)?\]\((\S+)(?: ["“](.+)["”])?\)/gi
 
 /**
  * Input rule built specifically for the `Link` extension, which ignores the auto-linked URL in
@@ -30,7 +26,7 @@ function linkInputRule(config: Parameters<typeof markInputRule>[0]) {
 
     return new InputRule({
         find: config.find,
-        handler: (props) => {
+        handler(props) {
             const { tr } = props.state
 
             defaultMarkInputRule.handler(props)
@@ -51,7 +47,7 @@ function linkPasteRule(config: Parameters<typeof markPasteRule>[0]) {
 
     return new PasteRule({
         find: config.find,
-        handler: (props) => {
+        handler(props) {
             const { tr } = props.state
 
             defaultMarkInputRule.handler(props)


### PR DESCRIPTION
## Overview

This will help with Doist/Issues#8630.

This fixes the aforementioned issue by having a more lenient RegExp for the `RichTextLink` extension input/paste rules. Instead of having a strict RegExp, where we only allow certain characters, we now allow pretty much anything except for whitespace characters (i.e. `\S`). This way, it's up to the user to be sure they are using a valid URL, instead of placing the onus on the editor.

## PR Checklist

-   [ ] Changes introduced here have been manually tested by someone other than the PR author
-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Paste the following in the `content` control (at the bottom):
    ```
    [Link-1](doist.dev

    [Link-2](https://doist.dev

    [Link-3](https://doist.dev/example

    [Link-4](https://doist.dev/example/file.html

    [Link-5](https://doist.dev/example/file.html?foo

    [Link-6](https://doist.dev/example/file.html?foo=bar

    [Link-7](https://doist.dev/example/file.html?foo=bar&baz=qux

    [Link-8](https://doist.dev/example/foo-bar.html?baz=qux%20quux
    ```
    - Alternatively, paste directly into the editor with `Cmd/Ctrl+Shift+V`
- For each link in the editor, type `)` at the end
    - [ ] Observe that that Markdown output is exactly what you would expect