### PR TITLE
feat: Disallow suggestions inside inline code marks and code blocks

### DIFF
--- a/src/factories/create-suggestion-extension.ts
+++ b/src/factories/create-suggestion-extension.ts
@@ -4,6 +4,8 @@ import { camelCase, kebabCase } from 'lodash-es'
 import { PluginKey } from 'prosemirror-state'
 
 import { SUGGESTION_EXTENSION_PRIORITY } from '../constants/extension-priorities'
+import { canInsertNodeAt } from '../utilities/can-insert-node-at'
+import { canInsertSuggestion } from '../utilities/can-insert-suggestion'
 
 import type {
     SuggestionKeyDownProps as CoreSuggestionKeyDownProps,
@@ -268,10 +270,11 @@ function createSuggestionExtension<
                             ) || []
                         )
                     },
-                    allow({ editor, range }) {
-                        return editor.can().insertContentAt(range, {
-                            type: nodeType,
-                        })
+                    allow({ editor, range, state }) {
+                        return (
+                            canInsertNodeAt({ editor, nodeType, range }) &&
+                            canInsertSuggestion({ editor, state })
+                        )
                     },
                     command({ editor, range, props }) {
                         const nodeAfter = editor.view.state.selection.$to.nodeAfter

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,8 @@ export { createSuggestionExtension } from './factories/create-suggestion-extensi
 export { isMultilineDocument, isPlainTextDocument } from './helpers/schema'
 export { createHTMLSerializer } from './serializers/html/html'
 export { createMarkdownSerializer } from './serializers/markdown/markdown'
+export { canInsertNodeAt } from './utilities/can-insert-node-at'
+export { canInsertSuggestion } from './utilities/can-insert-suggestion'
 export type { AnyConfig, Editor as CoreEditor, EditorEvents, MarkRange, Range } from '@tiptap/core'
 export {
     combineTransactionSteps,

--- a/src/utilities/can-insert-node-at.ts
+++ b/src/utilities/can-insert-node-at.ts
@@ -1,0 +1,22 @@
+import { Editor, Range } from '@tiptap/core'
+
+/**
+ * Check if a node of a specific type can be inserted at a specific position in the editor.
+ *
+ * @return True if the node can be inserted, false otherwise.
+ */
+function canInsertNodeAt({
+    editor,
+    nodeType,
+    range,
+}: {
+    editor: Editor
+    nodeType: string
+    range: Range
+}) {
+    return editor.can().insertContentAt(range, {
+        type: nodeType,
+    })
+}
+
+export { canInsertNodeAt }

--- a/src/utilities/can-insert-suggestion.ts
+++ b/src/utilities/can-insert-suggestion.ts
@@ -1,0 +1,29 @@
+import { Editor } from '@tiptap/core'
+import { EditorState } from '@tiptap/pm/state'
+
+/**
+ * Check if a suggestion can be inserted within the current editor selection.
+ *
+ * @return True if the suggestion can be inserted, false otherwise.
+ */
+function canInsertSuggestion({ editor, state }: { editor: Editor; state: EditorState }) {
+    const { selection } = state
+
+    const isInsideCodeMark = editor.isActive('code')
+
+    const isInsideCodeBlockNode = selection.$from.parent.type.name === 'codeBlock'
+
+    const hasCodeMarkBefore = state.doc
+        .nodeAt(selection.$from.parentOffset - 1)
+        ?.marks.some((mark) => mark.type.name === 'code')
+
+    const isComposingInlineCode = selection.$from.nodeBefore?.text
+        ?.split(' ')
+        .some((word) => word.startsWith('`'))
+
+    return (
+        !isInsideCodeMark && !isInsideCodeBlockNode && !hasCodeMarkBefore && !isComposingInlineCode
+    )
+}
+
+export { canInsertSuggestion }

--- a/stories/documentation/reference/utilities.md
+++ b/stories/documentation/reference/utilities.md
@@ -1,0 +1,11 @@
+# Utilities
+
+Utilities are public helper functions that can be used by custom extensions implemented in the consuming applications. The intent is to provide small reusable functions with the DRY principle in mind.
+
+## `canInsertNodeAt`
+
+This function is a shorthand to `editor.can().insertContentAt()`, and checks if a node of a specific type can be inserted at a specific position in the editor.
+
+## `canInsertSuggestion`
+
+This function checks if a suggestion – like a mention – can be inserted within the current editor selection, and the main purpose is to check for all possible edge cases and disallow suggestions from being inserted within inline code marks or code blocks.

--- a/stories/documentation/reference/utilities.story.mdx
+++ b/stories/documentation/reference/utilities.story.mdx
@@ -1,0 +1,17 @@
+import { Meta } from '@storybook/addon-docs'
+
+import { MarkdownRenderer } from '../../components/markdown-renderer.tsx'
+
+import rawUtilities from './utilities.md?raw'
+
+<Meta
+    title="Documentation/Reference/Utilities"
+    parameters={{
+        viewMode: 'docs',
+        options: {
+            isToolshown: false,
+        },
+    }}
+/>
+
+<MarkdownRenderer markdown={rawUtilities} />


### PR DESCRIPTION
## Overview

While debugging some other issue I've realized that we are currently allowing suggestions (like mentions and channel/thread references on Twist) to be inserted inside inline code marks and code blocks. This behaviour should be disallowed, and it's something we already do for Quick Actions on Twist, but not for anything else.

This PR implements the same behaviour that we have on Quick Actions inside the `createSuggestionExtension` factory so that all suggestion extensions built with that factory function automatically disallow suggestions when appropriate. The behaviour is implemented as a small reusable function that is exported publicly so that it can be used by custom extensions implemented in the consuming applications. This will be useful for all our custom suggestion-like extensions implemented on Todoist, and we'll also be able to replace the custom implementation found on Quick Actions on Twist.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
-   [x] Added/updated documentation to Storybook or `README.md`

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Start typing something and open an inline code mark with the ` character
- Make sure **you have a space** before the text cursor, and type `@`
    - [x] Observe that the mention suggestion DOES NOT appear
- Delete everything on the editor for the next test...
- Type a sentence with multiple words, select the whole sentence and press `Ctrl + E` (or `Cmd + E`)
- Move the text cursor inside the inline code mark just created
- Make sure **you have a space** before the text cursor, and type `@`
    - [x] Observe that the mention suggestion does NOT appear
- Move the text cursor to the end of the paragraph
- Make sure **there isn't a space** between the inline code mark and the text cursor, and type `@`
    - [x] Observe that the mention suggestion does NOT appear
- Now insert a space, and type `@` again
    - [x] Observe that the mention suggestion does appear
- Delete everything on the editor for the next test...
- Insert a code block with 3 backticks: ```
- Inside the code block, without typing anything else type `@`
    - [x] Observe that the mention suggestion does NOT appear