### PR TITLE
fix: Invalid `hasCodeMarkBefore` check in `canInsertSuggestion` utility function

### DIFF
--- a/src/utilities/can-insert-node-at.ts
+++ b/src/utilities/can-insert-node-at.ts
@@ -1,4 +1,4 @@
-import { Editor, Range } from '@tiptap/core'
+import type { Editor, Range } from '@tiptap/core'
 
 /**
  * Check if a node of a specific type can be inserted at a specific position in the editor.

--- a/src/utilities/can-insert-suggestion.ts
+++ b/src/utilities/can-insert-suggestion.ts
@@ -1,5 +1,5 @@
-import { Editor } from '@tiptap/core'
-import { EditorState } from '@tiptap/pm/state'
+import type { Editor } from '@tiptap/core'
+import type { EditorState } from '@tiptap/pm/state'
 
 /**
  * Check if a suggestion can be inserted within the current editor selection.
@@ -13,13 +13,15 @@ function canInsertSuggestion({ editor, state }: { editor: Editor; state: EditorS
 
     const isInsideCodeBlockNode = selection.$from.parent.type.name === 'codeBlock'
 
-    const hasCodeMarkBefore = state.doc
-        .nodeAt(selection.$from.parentOffset - 1)
-        ?.marks.some((mark) => mark.type.name === 'code')
+    const wordsBeforeSelection = (selection.$from.nodeBefore?.text ?? '').split(' ')
 
-    const isComposingInlineCode = selection.$from.nodeBefore?.text
-        ?.split(' ')
-        .some((word) => word.startsWith('`'))
+    const hasCodeMarkBefore =
+        (selection.$from.parent.cut(
+            selection.$from.parentOffset - wordsBeforeSelection.slice(-1)[0].length - 1,
+            selection.$from.parentOffset - 1,
+        ).content.firstChild?.marks.length ?? 0) > 0
+
+    const isComposingInlineCode = wordsBeforeSelection.some((word) => word.startsWith('`'))
 
     return (
         !isInsideCodeMark && !isInsideCodeBlockNode && !hasCodeMarkBefore && !isComposingInlineCode


### PR DESCRIPTION
## Overview

Pushes a small fix to the `hasCodeMarkBefore` check in `canInsertSuggestion` utility function where it prevented suggestions from being triggered in special edge case conditions hard to pinpoint (introduced with #154).

The solution here implemented is also more robust, and allows for suggestion extensions trigger to have more than a single character, which is required to make all our suggestion extensions (namely the Priority one in Todoist, triggered with `!!`) consistent.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)