### PR TITLE
fix(markdown-serializer): Add custom rule to escape horizontal rules for rich-text

### DIFF
--- a/src/serializers/markdown/markdown.test.ts
+++ b/src/serializers/markdown/markdown.test.ts
@@ -636,6 +636,45 @@ See the section on [\`code\`](#code).`,
                     ).toBe(`- 1968\\. A great year!
 - I think 1969 was second best.`)
                 })
+
+                test('horizontal rules syntax (with uncompletable tasks support) is escaped correctly', () => {
+                    expect(
+                        markdownSerializer.serialize(`<p>***</p>
+<p>* ***</p>
+<p>*********</p>
+<p>* *********</p>
+<p>---</p>
+<p>* ---</p>
+<p>---------</p>
+<p>* ---------</p>
+<p>___</p>
+<p>* ___</p>
+<p>_________</p>
+<p>* _________</p>`),
+                    ).toBe(`\\***
+
+* \\***
+
+\\*********
+
+* \\*********
+
+\\---
+
+* \\---
+
+\\---------
+
+* \\---------
+
+\\___
+
+* \\___
+
+\\_________
+
+* \\_________`)
+                })
             })
         })
 

--- a/src/serializers/markdown/markdown.ts
+++ b/src/serializers/markdown/markdown.ts
@@ -120,6 +120,13 @@ function createMarkdownSerializer(schema: Schema): MarkdownSerializerReturnType 
                     // make sure that text context that matches the ordered list syntax is
                     // correctly escaped in order to be interpreted as text.
                     .replace(/^(\d+)\.(\s.+|$)/, '$1\\.$2')
+
+                    // When an editor is configured without support for horizontal rules, we need to
+                    // make sure that all horizontal rule patterns in the CommonMark specification
+                    // are properly escaped so that it's interpreted as text and not Markdown. This
+                    // regular expression includes additional support for the uncompletable tasks
+                    // syntax in Todoist (such tasks start with `*<space>`).
+                    .replace(/(^|^\*\s)(\*{3,}|-{3,}|_{3,})/, '$1\\$2')
             )
         }
     }


### PR DESCRIPTION
## Overview

With #102 we overrode Turndown's escape mechanism with our custom implementation with custom rules to overcome the agressive rules built-in the default implementation. Before making this a permanent change, we tested the custom implementation in production for more than a month, and since no bugs were reported during that time, we decided to keep it. However, caused by this custom escape mechanism, we recently got our first bug report ([ref](https://github.com/Doist/Issues/issues/9658)). This PR fixes that issue by adding a custom rule to the custom escape mechanism.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
-   [x] Added/updated unit test cases and/or end-to-end test cases

## Test plan

The new custom rule is already fully tested by the added unit test, and unfortunately it's not possible to manually test this without making changes to the Storybook editor, which makes for a cumbersome test plan.