### PR TITLE
chore(storybook): Fix toolbar state not updated immediately after an editor state change

### DIFF
--- a/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-toolbar.tsx
+++ b/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-toolbar.tsx
@@ -46,7 +46,7 @@ function TypistEditorToolbar({ editor }: TypistEditorToolbarProps) {
     useEffect(
         function initializeEventListeners() {
             function handleTransactionUpdate() {
-                // Force a rerender for every selection update in the editor - an event that ocurrs
+                // Force a rerender for every transaction in the editor - an event that ocurrs
                 // outside of the React lifecycle - to update the toolbar buttons `pressed` state
                 forceRerender()
             }

--- a/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-toolbar.tsx
+++ b/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-toolbar.tsx
@@ -45,16 +45,16 @@ function TypistEditorToolbar({ editor }: TypistEditorToolbarProps) {
 
     useEffect(
         function initializeEventListeners() {
-            function handleSelectionUpdate() {
+            function handleTransactionUpdate() {
                 // Force a rerender for every selection update in the editor - an event that ocurrs
                 // outside of the React lifecycle - to update the toolbar buttons `pressed` state
                 forceRerender()
             }
 
-            editor.on('selectionUpdate', handleSelectionUpdate)
+            editor.on('transaction', handleTransactionUpdate)
 
             return function cleanupEventListeners() {
-                editor.off('selectionUpdate', handleSelectionUpdate)
+                editor.off('transaction', handleTransactionUpdate)
             }
         },
         [editor, forceRerender],


### PR DESCRIPTION
<!-- Thank you for your contribution to the Typist repository. -->

<!-- Please remove all sections that are not relevant. -->

## Overview

<!-- Please include a summary of the changes and the related issue. -->
<!-- Please also include relevant motivation and context. -->
This PR tries to fix #259 by replacing the eventListener on Storybook.

### Changes Introduced
* `onSelectionUpdate` changed to `onTransation` on `typist editor toolbar decorator`.
    ```javascript
    editor.on('selectionUpdate', handleSelectionUpdate)
    // is changed to
    editor.on('transaction', handleTransactionUpdate)
    ```
Thanks!

## PR Checklist

<!-- Feel free to remove the lines that are not applicable or leave them unchecked. -->

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
-   [ ] Added/updated unit test cases and/or end-to-end test cases
-   [ ] Added/updated documentation to Storybook or `README.md`

## Test plan
Doesn't change any existing features, just introduces fix for #259.
<!-- Please add a complete step-by-step description on how to test the changes. -->

<!--
- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Do something else…
    - [ ] Observe that this happened
-->

## Demo

| Before                      | After                      |
| --------------------------- | -------------------------- |
| Keyboard events and editor button clicks did not update the toolbar | Keyboard shortcuts and toolbar clicks correctly re-render editor toolbar.|
| ![image](https://github.com/Doist/typist/assets/36472216/54c17c0c-86fe-4908-bd37-ca0a26163e64) | ![image](https://github.com/Doist/typist/assets/36472216/0844ad99-1522-4140-a97c-7d1baadada9a)|
