### PR TITLE
build: Fix npm package provenance (npmjs + GitHub)

### DIFF
--- a/.github/workflows/publish-typist-package-release.yml
+++ b/.github/workflows/publish-typist-package-release.yml
@@ -9,6 +9,10 @@ on:
         types:
             - completed
 
+permissions:
+    # Enable the use of OIDC for npm provenance
+    id-token: write
+
 # The release workflow involves many crucial steps that once triggered it shouldn't be cancelled
 # until it's finished, otherwise we might end up in an inconsistent state (e.g., a new release
 # published to npm but not GitHub Packages). To prevent this, concurrency is disabled with
@@ -83,6 +87,6 @@ jobs:
             - name: Publish package to GitHub Packages
               if: ${{ steps.semantic-release.outputs.package-published == 'true' }}
               run: |
-                  npm publish --provenance
+                  npm publish
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "npm": "^7.0.0 || ^8.0.0 || ^9.0.0"
     },
     "publishConfig": {
-        "access": "public"
+        "access": "public",
+        "provenance": true
     },
     "files": [
         "CHANGELOG.md",


### PR DESCRIPTION
## Overview

This PR fixes the npm package provenance for both npmjs and GitHub Packages by adding the missing permission to the workflow, and moving the `provenance` flag to `package.json` (this is required because we use `semantic-release` to publish to npmjs which doesn't provide direct access to the publish command, so all configuration must be done through `package.json`).

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

This is impossible to test without force publishing a new release.