### PR TITLE
revert: "Add support to publish experimental releases"

### DIFF
--- a/.github/workflows/publish-typist-package-release.yml
+++ b/.github/workflows/publish-typist-package-release.yml
@@ -1,7 +1,6 @@
 name: Typist Package Release
 
 on:
-    workflow_dispatch:
     workflow_run:
         workflows:
             - CI Validation
@@ -29,11 +28,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 60
 
-        # Only run this job when manually triggered for the `experimental` branch, or when triggered
-        # by the `CI Validation` workflow for the `main` branch
-        if: |
-            (github.event_name == 'workflow_dispatch' && contains(github.ref, 'experimental')) ||
-            (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        if: github.event.workflow_run.conclusion == 'success'
 
         steps:
             - name: Checkout repository
@@ -95,19 +90,3 @@ jobs:
                   npm publish
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    fail-manual-trigger:
-        name: Release & Publish
-        runs-on: ubuntu-latest
-        timeout-minutes: 60
-
-        # Only run this job when manually triggered for all branches with the exception for the
-        # `experimental` branch (which is the only branch allowed to be manually triggered)
-        if: github.event_name == 'workflow_dispatch' && !contains(github.ref, 'experimental')
-
-        steps:
-            - name: Fail job with a message
-              uses: actions/github-script@v6
-              with:
-                  script: |
-                      core.setFailed('Triggering this workflow manually is only allowed for the `experimental` branch.')

--- a/.releaserc
+++ b/.releaserc
@@ -1,10 +1,6 @@
 {
     "branches": [
-        "main",
-        {
-            "name": "experimental",
-            "prerelease": true
-        }
+        "main"
     ],
     "plugins": [
         [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,13 +66,6 @@ After cloning Typist and installing all dependencies, several commands are at yo
 
 The release process for Typist is almost fully automated with [`semantic-release`](https://github.com/semantic-release/semantic-release), only requiring a core team member to trigger [this workflow](https://github.com/Doist/typist/actions/workflows/publish-typist-package-release.yml) manually whenever a new release needs to be published.
 
-#### Experimental Releases
-
-Sometimes the need for an experimental release arises before a new feature or fix is ready for a stable release. In these cases, we can publish an experimental release by pushing code to the `experimental` branch, and manually triggering the [this workflow](https://github.com/Doist/typist/actions/workflows/publish-typist-package-release.yml). The version number will be automatically picked by `semantic-release`, and `-experimental.x` will be appended at the end of the version number, where `x` represents the number of experimental release published to the `experimental` branch.
-
-> **Warning**
-> The `experimental` branch should never be deleted nor rebased with `main`, otherwise we might lose the Git tags required for `semantic-release` to properly pick the next experimental version number. Instead, `main` should be merged into the `experimental` branch with a merge commit before pushing new code to the `experimental` branch, so that those experiments are always published with the latest published stable version.
-
 ### Visual Studio Code
 
 #### CSS Modules for Storybook


### PR DESCRIPTION
## Overview

This PR reverts Doist/typist#278 because I realized that the approach was bit finicky, and it would probably produce unexpected version numbers. So, for now, I'm reverting the changes before I can put some more thought into this.