### PR TITLE
ci: Allow authenticated operations against the GitHub Packages registry

### DIFF
--- a/.github/workflows/publish-typist-package-release.yml
+++ b/.github/workflows/publish-typist-package-release.yml
@@ -12,6 +12,9 @@ on:
 permissions:
     # Enable the use of OIDC for npm provenance
     id-token: write
+    # Enable the use of GitHub Packages registry
+    contents: read
+    packages: write
 
 # The release workflow involves many crucial steps that once triggered it shouldn't be cancelled
 # until it's finished, otherwise we might end up in an inconsistent state (e.g., a new release


### PR DESCRIPTION
## Overview

When the `permissions` key was first introduced in https://github.com/Doist/typist/pull/268 it made sure that all **unspecified** permissions where set to "no access" ([ref](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)), which prevented authenticated operations against the GitHub Packages registry. Because of this, publishing Typist to the GitHub Package registry started to fail. This PR attempts to fix that issue by providing the minimal required permissions for read/write access to the GitHub Packages registry.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

The only way to test this is to wait for the next public release, and see if the package was successfully published to both the npm registry, and GitHub Packages registry.
