### PR TITLE
feat: Add the `PasteHTMLTableAsString` extension

### DIFF
--- a/src/constants/extension-priorities.ts
+++ b/src/constants/extension-priorities.ts
@@ -13,6 +13,13 @@ const SUGGESTION_EXTENSION_PRIORITY = 1000
 const SMART_MARKDOWN_TYPING_PRIORITY = 110
 
 /**
+ * Priority for the `PasteSpreadsheetTable` extension. This needs to be higher than most paste
+ * extensions (e.g., `PasteSinglelineText`, `PasteMarkdown`, etc.), so that the extension can first
+ * parse HTML tables that might exist in the clipboard data.
+ */
+const PASTE_EXTENSION_PRIORITY = 105
+
+/**
  * Priority for the `ViewEventHandlers` extension. This needs to be higher than the default for most
  * of the built-in and official extensions (i.e. `100`), so that the event handlers from the
  * extension can take precedence over the built-in and official extensions event handlers.
@@ -28,6 +35,7 @@ const BLOCKQUOTE_EXTENSION_PRIORITY = 101
 
 export {
     BLOCKQUOTE_EXTENSION_PRIORITY,
+    PASTE_EXTENSION_PRIORITY,
     SMART_MARKDOWN_TYPING_PRIORITY,
     SUGGESTION_EXTENSION_PRIORITY,
     VIEW_EVENT_HANDLERS_PRIORITY,

--- a/src/constants/extension-priorities.ts
+++ b/src/constants/extension-priorities.ts
@@ -13,7 +13,7 @@ const SUGGESTION_EXTENSION_PRIORITY = 1000
 const SMART_MARKDOWN_TYPING_PRIORITY = 110
 
 /**
- * Priority for the `PasteSpreadsheetTable` extension. This needs to be higher than most paste
+ * Priority for the `PasteHTMLTableAsString` extension. This needs to be higher than most paste
  * extensions (e.g., `PasteSinglelineText`, `PasteMarkdown`, etc.), so that the extension can first
  * parse HTML tables that might exist in the clipboard data.
  */

--- a/src/extensions/plain-text/plain-text-kit.ts
+++ b/src/extensions/plain-text/plain-text-kit.ts
@@ -4,8 +4,8 @@ import { Text } from '@tiptap/extension-text'
 import { Typography } from '@tiptap/extension-typography'
 
 import { CopyMarkdownSource } from '../shared/copy-markdown-source'
+import { PasteHTMLTableAsString } from '../shared/paste-html-table-as-string'
 import { PasteSinglelineText } from '../shared/paste-singleline-text'
-import { PasteSpreadsheetTable } from '../shared/paste-spreadsheet-table'
 
 import { SmartMarkdownTyping } from './smart-markdown-typing/smart-markdown-typing'
 import { PasteMultilineText } from './paste-multiline-text'
@@ -36,9 +36,9 @@ type PlainTextKitOptions = {
     paragraph: Partial<PlainTextParagraphOptions> | false
 
     /**
-     * Set to `false` to disable the `PasteSpreadsheetTable` extension.
+     * Set to `false` to disable the `PasteHTMLTableAsString` extension.
      */
-    pasteSpreadsheetTable: false
+    pasteHTMLTableAsString: false
 
     /**
      * Set to `false` to disable the `Text` extension.
@@ -79,9 +79,9 @@ const PlainTextKit = Extension.create<PlainTextKitOptions>({
                     : PasteMultilineText,
             )
 
-            if (this.options?.pasteSpreadsheetTable !== false) {
+            if (this.options?.pasteHTMLTableAsString !== false) {
                 // Supports pasting tables (from spreadsheets and websites) into the editor
-                extensions.push(PasteSpreadsheetTable)
+                extensions.push(PasteHTMLTableAsString)
             }
         }
 

--- a/src/extensions/plain-text/plain-text-kit.ts
+++ b/src/extensions/plain-text/plain-text-kit.ts
@@ -5,6 +5,7 @@ import { Typography } from '@tiptap/extension-typography'
 
 import { CopyMarkdownSource } from '../shared/copy-markdown-source'
 import { PasteSinglelineText } from '../shared/paste-singleline-text'
+import { PasteSpreadsheetTable } from '../shared/paste-spreadsheet-table'
 
 import { SmartMarkdownTyping } from './smart-markdown-typing/smart-markdown-typing'
 import { PasteMultilineText } from './paste-multiline-text'
@@ -33,6 +34,11 @@ type PlainTextKitOptions = {
      * Set options for the `Paragraph` extension, or `false` to disable.
      */
     paragraph: Partial<PlainTextParagraphOptions> | false
+
+    /**
+     * Set to `false` to disable the `PasteSpreadsheetTable` extension.
+     */
+    pasteSpreadsheetTable: false
 
     /**
      * Set to `false` to disable the `Text` extension.
@@ -72,6 +78,11 @@ const PlainTextKit = Extension.create<PlainTextKitOptions>({
                     ? PasteSinglelineText
                     : PasteMultilineText,
             )
+
+            if (this.options?.pasteSpreadsheetTable !== false) {
+                // Supports pasting tables (from spreadsheets and websites) into the editor
+                extensions.push(PasteSpreadsheetTable)
+            }
         }
 
         if (this.options.history !== false) {

--- a/src/extensions/rich-text/rich-text-image.ts
+++ b/src/extensions/rich-text/rich-text-image.ts
@@ -185,6 +185,11 @@ const RichTextImage = Image.extend<RichTextImageOptions>({
                             return false
                         }
 
+                        // Do not handle the event if there are multiple clipboard types
+                        if ((event.clipboardData?.types || []).length > 1) {
+                            return false
+                        }
+
                         const pastedFiles = Array.from(event.clipboardData?.files || [])
 
                         // Do not handle the event if no files were pasted

--- a/src/extensions/rich-text/rich-text-kit.ts
+++ b/src/extensions/rich-text/rich-text-kit.ts
@@ -21,6 +21,7 @@ import { Typography } from '@tiptap/extension-typography'
 import { BLOCKQUOTE_EXTENSION_PRIORITY } from '../../constants/extension-priorities'
 import { CopyMarkdownSource } from '../shared/copy-markdown-source'
 import { PasteSinglelineText } from '../shared/paste-singleline-text'
+import { PasteSpreadsheetTable } from '../shared/paste-spreadsheet-table'
 
 import { BoldAndItalics } from './bold-and-italics'
 import { CurvenoteCodemark } from './curvenote-codemark'
@@ -160,6 +161,11 @@ type RichTextKitOptions = {
     pasteSinglelineText: false
 
     /**
+     * Set to `false` to disable the `PasteSpreadsheetTable` extension.
+     */
+    pasteSpreadsheetTable: false
+
+    /**
      * Set options for the `Strike` extension, or `false` to disable.
      */
     strike: Partial<StrikeOptions> | false
@@ -241,6 +247,11 @@ const RichTextKit = Extension.create<RichTextKitOptions>({
                 // Supports pasting multiple lines into a singleline editor, by joining all the
                 // pasted lines together
                 extensions.push(PasteSinglelineText)
+            }
+
+            if (this.options?.pasteSpreadsheetTable !== false) {
+                // Supports pasting tables (from spreadsheets and websites) into the editor
+                extensions.push(PasteSpreadsheetTable)
             }
         }
 

--- a/src/extensions/rich-text/rich-text-kit.ts
+++ b/src/extensions/rich-text/rich-text-kit.ts
@@ -20,8 +20,8 @@ import { Typography } from '@tiptap/extension-typography'
 
 import { BLOCKQUOTE_EXTENSION_PRIORITY } from '../../constants/extension-priorities'
 import { CopyMarkdownSource } from '../shared/copy-markdown-source'
+import { PasteHTMLTableAsString } from '../shared/paste-html-table-as-string'
 import { PasteSinglelineText } from '../shared/paste-singleline-text'
-import { PasteSpreadsheetTable } from '../shared/paste-spreadsheet-table'
 
 import { BoldAndItalics } from './bold-and-italics'
 import { CurvenoteCodemark } from './curvenote-codemark'
@@ -161,9 +161,9 @@ type RichTextKitOptions = {
     pasteSinglelineText: false
 
     /**
-     * Set to `false` to disable the `PasteSpreadsheetTable` extension.
+     * Set to `false` to disable the `PasteHTMLTableAsString` extension.
      */
-    pasteSpreadsheetTable: false
+    pasteHTMLTableAsString: false
 
     /**
      * Set options for the `Strike` extension, or `false` to disable.
@@ -249,9 +249,9 @@ const RichTextKit = Extension.create<RichTextKitOptions>({
                 extensions.push(PasteSinglelineText)
             }
 
-            if (this.options?.pasteSpreadsheetTable !== false) {
+            if (this.options?.pasteHTMLTableAsString !== false) {
                 // Supports pasting tables (from spreadsheets and websites) into the editor
-                extensions.push(PasteSpreadsheetTable)
+                extensions.push(PasteHTMLTableAsString)
             }
         }
 

--- a/src/extensions/shared/paste-html-table-as-string.ts
+++ b/src/extensions/shared/paste-html-table-as-string.ts
@@ -5,7 +5,7 @@ import { PASTE_EXTENSION_PRIORITY } from '../../constants/extension-priorities'
 import { parseHtmlToElement } from '../../helpers/dom'
 
 /**
- * The `PasteSpreadsheetTable` extension adds the ability to paste a table copied from a spreadsheet
+ * The `PasteHTMLTableAsString` extension adds the ability to paste a table copied from a spreadsheet
  * web app (e.g., Google Sheets, Microsoft Excel), along with tables rendered by GitHub Flavored
  * Markdown (GFM), into the editor.
  *
@@ -16,13 +16,13 @@ import { parseHtmlToElement } from '../../helpers/dom'
  * Lastly, please note that formatting is lost when the copied table comes from Google Sheets or
  * Microsoft Excel, because unfortunately, these apps style the cell contents using CSS.
  */
-const PasteSpreadsheetTable = Extension.create({
-    name: 'pasteSpreadsheetTable',
+const PasteHTMLTableAsString = Extension.create({
+    name: 'pasteHTMLTableAsString',
     priority: PASTE_EXTENSION_PRIORITY,
     addProseMirrorPlugins() {
         return [
             new Plugin({
-                key: new PluginKey('pasteSpreadsheetTable'),
+                key: new PluginKey('pasteHTMLTableAsString'),
                 props: {
                     transformPastedHTML(html) {
                         // Attempt to extract a table HTML from the pasted HTML
@@ -71,4 +71,4 @@ const PasteSpreadsheetTable = Extension.create({
     },
 })
 
-export { PasteSpreadsheetTable }
+export { PasteHTMLTableAsString }

--- a/src/extensions/shared/paste-singleline-text.ts
+++ b/src/extensions/shared/paste-singleline-text.ts
@@ -26,7 +26,7 @@ const PasteSinglelineText = Extension.create({
                             // Join break lines with a space character in-between
                             .replace(/<br>/g, ' ')
                             // Join paragraphs with a space character in-between
-                            .replace(/<p[^>]+>(.*?)<\/p>/g, '$1 ')
+                            .replace(/<p[^>]*>(.*?)<\/p>/g, '$1 ')
 
                         return isPlainTextDocument(view.state.schema)
                             ? escape(bodyElement.innerText)

--- a/src/extensions/shared/paste-spreadsheet-table.ts
+++ b/src/extensions/shared/paste-spreadsheet-table.ts
@@ -1,0 +1,74 @@
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from 'prosemirror-state'
+
+import { PASTE_EXTENSION_PRIORITY } from '../../constants/extension-priorities'
+import { parseHtmlToElement } from '../../helpers/dom'
+
+/**
+ * The `PasteSpreadsheetTable` extension adds the ability to paste a table copied from a spreadsheet
+ * web app (e.g., Google Sheets, Microsoft Excel), along with tables rendered by GitHub Flavored
+ * Markdown (GFM), into the editor.
+ *
+ * Since Typist does not yet support tables, this extension simply pastes the table as a string of
+ * paragraphs (one paragraph per row), with each cell separated by a space character. However,
+ * whenever we do add support for tables, this extension will need to be completely rewritten.
+ *
+ * Lastly, please note that formatting is lost when the copied table comes from Google Sheets or
+ * Microsoft Excel, because unfortunately, these apps style the cell contents using CSS.
+ */
+const PasteSpreadsheetTable = Extension.create({
+    name: 'pasteSpreadsheetTable',
+    priority: PASTE_EXTENSION_PRIORITY,
+    addProseMirrorPlugins() {
+        return [
+            new Plugin({
+                key: new PluginKey('pasteSpreadsheetTable'),
+                props: {
+                    transformPastedHTML(html) {
+                        // Attempt to extract a table HTML from the pasted HTML
+                        const tableHTML = /<table[^>]+>[\s\S]*?<\/table>/gi.exec(html)
+
+                        // Do not handle the event if a table was not found
+                        if (!tableHTML) {
+                            return html
+                        }
+
+                        const { firstElementChild: tableElement } = parseHtmlToElement(
+                            tableHTML[0],
+                        ) as {
+                            firstElementChild: HTMLTableElement | null
+                        }
+
+                        // Do not handle the event if we don't have a table element
+                        if (!tableElement) {
+                            return html
+                        }
+
+                        // Transform the table element into a string of paragraphs
+                        return (
+                            Array.from(tableElement.rows)
+                                // Join each cell into a single string for each row
+                                .reduce<string[]>((acc, row) => {
+                                    return [
+                                        ...acc,
+                                        Array.from(row.cells)
+                                            // Use `innerHTML` instead of `innerText` to preserve
+                                            // potential formatting (e.g., GFM) within each cell
+                                            .map((cell) => cell.innerHTML)
+                                            .join(' '),
+                                    ]
+                                }, [])
+                                // Discard rows that are completely empty
+                                .filter((row) => row.trim().length > 0)
+                                // Wrap each row in a paragraph
+                                .map((row) => `<p>${row}</p>`)
+                                .join('')
+                        )
+                    },
+                },
+            }),
+        ]
+    },
+})
+
+export { PasteSpreadsheetTable }


### PR DESCRIPTION
## Overview

This PR introduces the `PasteHTMLTableAsString` extension, which adds the ability to paste a table copied from a spreadsheet web app (e.g., Google Sheets, Microsoft Excel), along with tables rendered by GitHub Flavored Markdown (GFM), into the editor.

This extension will help fix an internal issue where some users copy a list of rows from a spreadsheet web app and paste them into Todoist expecting to be prompted to add each row as a separate task (as if they were pasting multiple lines of text).

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Create a Google Sheet with a sample table (multiple columns/rows)
    - Copy and paste the table (or parts of it) into the editor
        - [x] Observe that each row is pasted into the editor as paragraph
        - [x] Observe that each column is separated by a ` ` character
- Create a Microsoft Excel document with a sample table (multiple columns/rows)
    - Copy and paste the table (or parts of it) into the editor
        - [ ] Observe that each row is pasted into the editor as paragraph
        - [ ] Observe that each column is separated by a ` ` character
- Create a Numbers (Apple) document with a sample table (multiple columns/rows)
    - Copy and paste the table (or parts of it) into the editor
        - [ ] Observe that each row is pasted into the editor as paragraph
        - [ ] Observe that each column is separated by a ` ` character

### GFM test

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Take the following Markdown table as input:
    | H1 | H2 | H3 |
    |--------|--------|--------|
    | _A1_ | A2 | A3 |
    | B1 | **B2** | B3 |
    | C1 | C2 | ~~C3~~ | 

    - Copy and paste the table (or parts of it) into the editor
        - [x] Observe that each row is pasted into the editor as paragraph
        - [x] Observe that each column is separated by a ` ` character
        - [x] Observe that formatting for the formatted cells is preserved

### Bonus tests

- You can try the same as above for the `Plain-text → Default` story, and most of the behaviour should be very similar. The small difference is that a tabular space (i.e. `\t`) will be used, instead of ` `) to separate columns.
- Regardless of the number of columns copied, if all cells within a row are empty, that row should be discarded (i.e. not even an empty paragraph will be shown)
- Feel free to think of other edge cases that some users might use, and let me know if something doesn't work as you'd expect

## Demos

### Typist

https://github.com/Doist/typist/assets/96476/eb90d340-b16c-47d3-8579-483f5efe4cf4

### Todoist

https://github.com/Doist/typist/assets/96476/8cab1c4b-21b9-4c1d-9c7e-0a62db8981af
