### PR TITLE
ci: Fix publishing to GitHub Packages registry

### DIFF
--- a/.github/workflows/publish-typist-package-release.yml
+++ b/.github/workflows/publish-typist-package-release.yml
@@ -13,8 +13,11 @@ permissions:
     # Enable the use of OIDC for npm provenance
     id-token: write
     # Enable the use of GitHub Packages registry
-    contents: read
     packages: write
+    # Enable `semantic-release` to publish a GitHub release and post comments on issues/PRs
+    contents: write
+    issues: write
+    pull-requests: write
 
 # The release workflow involves many crucial steps that once triggered it shouldn't be cancelled
 # until it's finished, otherwise we might end up in an inconsistent state (e.g., a new release
@@ -86,6 +89,11 @@ jobs:
                   node-version-file: .node-version
                   registry-url: https://npm.pkg.github.com/
                   scope: '@doist'
+
+            - name: Disable npm package provenance (unsupported by GitHub Packages)
+              if: ${{ steps.semantic-release.outputs.package-published == 'true' }}
+              run: |
+                  npm config set provenance false --location=project
 
             - name: Publish package to GitHub Packages
               if: ${{ steps.semantic-release.outputs.package-published == 'true' }}

--- a/.npmrc
+++ b/.npmrc
@@ -10,3 +10,6 @@ engine-strict=true
 
 # Save dependencies with an exact version rather than the semver range
 save-exact=true
+
+# Generate provenance statements for published packages
+provenance=true

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
         "npm": "^7.0.0 || ^8.0.0 || ^9.0.0"
     },
     "publishConfig": {
-        "access": "public",
-        "provenance": true
+        "access": "public"
     },
     "files": [
         "CHANGELOG.md",


### PR DESCRIPTION
## Overview

It looks like https://github.com/Doist/typist/pull/284 wasn't enough to fix the `Typist Package Release` workflow, and publishing to GitHub packages still failed on the [latest release](https://github.com/Doist/typist/actions/runs/5241511888/jobs/9463707293).

After digging a bit deeper into this issue, I couldn't get provenance working with the GitHub Packages registry. It looks to me that provenance is not supported with the GitHub Packages registry, and my research about this led me nowhere. The solution I found was to enable provenance by default on `.npmrc` (to publish to npmjs with provenance), and then disable it before publishing to the GitHub Packages registry.

@scottlovegrove assigning this `show` PR to you for awareness, since you're the one involved in impelementing provenance in the first place.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

As usual, this is the kind of change that can only be tested once the next release goes out. However, I personally used a forked repo to try the changes before pushing them into the real project, and I believe these changes to be okay.