### PR TITLE
chore(renovate): Remove old package patterns and add new ones

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,8 +6,12 @@
             "groupName": "tiptap packages"
         },
         {
-            "matchPackagePatterns": ["^prosemirror"],
-            "enabled": false
+            "matchPackagePatterns": ["gfm-autolink-literal"],
+            "groupName": "gfm autolink literal packages"
+        },
+        {
+            "matchPackagePatterns": ["gfm-strikethrough"],
+            "groupName": "gfm strikethrough packages"
         }
     ]
 }


### PR DESCRIPTION
## Overview

Removes the old `^prosemirror` match package pattern which is no longer required (Tiptap now uses a single dependency for ProseMirror dependencies, i.e. `@tiptap/pm`), and adds a couple of new match package patterns for `*-gfm-autolink-literal` and `*-gfm-strikethrough`, to group related dependencies updates in a single PR.

## PR Checklist

<!-- Feel free to remove the lines that are not applicable or leave them unchecked. -->

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)