### PR TITLE
chore(renovate): Replace peer dependencies range with newer one

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,10 @@
     "extends": ["github>doist/renovate-config:frontend-base"],
     "packageRules": [
         {
+            "matchDepTypes": ["peerDependencies"],
+            "rangeStrategy": "replace"
+        },
+        {
             "matchPackagePatterns": ["^@tiptap/"],
             "groupName": "tiptap packages"
         },


### PR DESCRIPTION
## Overview

Most of Typist peer dependencies are packages that when major versions are release, they are likely to break functionality. With that in mind, we are changing Renovate's configuration to completetly replace the `peerDependencies` range instead of widening to support multiple versions (which is not possible if the newest version contains a breaking change).

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)