### PR TITLE
chore(renovate): Use `fix` commit type for peer dependencies updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
     "packageRules": [
         {
             "matchDepTypes": ["peerDependencies"],
-            "rangeStrategy": "replace"
+            "rangeStrategy": "replace",
+            "semanticCommitType": "fix"
         },
         {
             "matchPackagePatterns": ["^@tiptap/"],


### PR DESCRIPTION
## Overview

This change should've been part of https://github.com/Doist/typist/pull/381 to force peer dependencies updates to publish a new release (once they are merged) since they affect the production code output.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
