### PR TITLE
chore(renovate): Disable automerge for tiptap packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
     "packageRules": [
         {
             "matchPackagePatterns": ["^@tiptap/"],
-            "groupName": "tiptap packages"
+            "groupName": "tiptap packages",
+            "automerge": false
         },
         {
             "matchPackagePatterns": ["gfm-autolink-literal"],


### PR DESCRIPTION
## Overview

While reviewing the latest tiptap release (v2.1), I've realized that it's not safe to bindly update to the latest tiptap version without double-checking that the considerable aumount of changes introduced in each version. For this reason, and for the time being, I'm disabling automerge for tiptap packages in Renovate.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
