### PR TITLE
fix(rich-text-link): Markdown pasting broken with conflicting `linkOnPaste` option

### DIFF
--- a/src/extensions/rich-text/rich-text-link.ts
+++ b/src/extensions/rich-text/rich-text-link.ts
@@ -57,12 +57,31 @@ function linkPasteRule(config: Parameters<typeof markPasteRule>[0]) {
 }
 
 /**
+ * The options available to customize the `RichTextLink` extension.
+ */
+type RichTextLinkOptions = Omit<
+    LinkOptions,
+    // The `linkOnPaste` option is not available in the `RichTextLink` extension, since we're using
+    // our own paste rules to handle Markdown syntax (see `addOptions` below)
+    'linkOnPaste'
+>
+
+/**
  * Custom extension that extends the built-in `Link` extension to add additional input/paste rules
  * for converting the Markdown link syntax (i.e. `[Doist](https://doist.com)`) into links, and also
  * adds support for the `title` attribute.
  */
-const RichTextLink = Link.extend({
+const RichTextLink = Link.extend<RichTextLinkOptions>({
     inclusive: false,
+    addOptions() {
+        return {
+            ...this.parent?.(),
+            // Disable the built-in auto-linking feature for pasted URLs, since we're using our own
+            // paste rules to handle Markdown syntax (on top of that, the `PasteMarkdown` extension
+            // takes precedence, and will handle auto-linking for pasted URLs anyway)
+            linkOnPaste: false,
+        }
+    },
     addAttributes() {
         return {
             ...this.parent?.(),
@@ -111,4 +130,4 @@ const RichTextLink = Link.extend({
 
 export { RichTextLink }
 
-export type { LinkOptions as RichTextLinkOptions }
+export type { RichTextLinkOptions }


### PR DESCRIPTION
## Overview

With the latest Tiptap version (https://github.com/Doist/typist/pull/407), the Link extension came with a new built-in `linkOnPaste` option (default: `true`), which conflicted with our own paste rules with support for Markdown syntax (in the `RichTextLink` extension), and our own `PasteMarkdown` extension with full support for Markdown pasting.

This PR simply forces `linkOnPaste` to be `false`, and disallows the option from being set to `true` in consumer apps. This is a workaround, as I believe this `linkOnPaste` option is not working as expected, and made an upstream comment about it [here](https://github.com/ueberdosis/tiptap/pull/4292#issuecomment-1695949926). If this is eventually fixed/improved in Tiptap, we can probably revert this change.

Making this a `show` PR so that I can push a quick fix to Todoist and Twist (we already started receiving reports about this).

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Copy the following content: `[Doist](https://doist.dev)`
- Paste it into the editor with `Ctrl + Shift + V` (or the macOS equivalent)
    - [ ] Observe that the editor will show the word "Doist" linked to https://doist.dev (visible in the "Markdown Output" section on the right side)

## Demo

| Before                      | After                      |
| --------------------------- | -------------------------- |
| ![firefox_CCo2mcZvxQ](https://github.com/Doist/typist/assets/96476/107c4035-bf7e-436f-9f8d-0a53038ec352) | ![firefox_vS3HwJATeQ](https://github.com/Doist/typist/assets/96476/43da5a98-6a4c-442a-9764-d17563906656) |



