### PR TITLE
fix(rich-text-kit): Allow the `ListKeymap` extension to be configured

### DIFF
--- a/src/extensions/rich-text/rich-text-kit.ts
+++ b/src/extensions/rich-text/rich-text-kit.ts
@@ -306,7 +306,7 @@ const RichTextKit = Extension.create<RichTextKitOptions>({
         }
 
         if (this.options.listKeymap !== false) {
-            extensions.push(ListKeymap)
+            extensions.push(ListKeymap.configure(this.options?.listKeymap))
         }
 
         if (this.options.orderedList !== false) {


### PR DESCRIPTION
## Overview

A small bugfix that allows the `ListKeymap` extension to be configured (introduced in #398).

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)