### PR TITLE
chore(deps): update dependency semantic-release to v22.0.0-beta.2

### DIFF
--- a/.github/workflows/publish-typist-package-release.yml
+++ b/.github/workflows/publish-typist-package-release.yml
@@ -1,6 +1,7 @@
 name: Typist Package Release
 
 on:
+    workflow_dispatch:
     workflow_run:
         workflows:
             - CI Validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
                 "react-markdown": "8.0.7",
                 "react-syntax-highlighter": "15.5.0",
                 "rimraf": "5.0.1",
-                "semantic-release": "21.1.1",
+                "semantic-release": "22.0.0-beta.2",
                 "storybook": "7.4.0",
                 "storybook-css-modules": "1.0.8",
                 "type-fest": "4.3.1",
@@ -3610,44 +3610,44 @@
             }
         },
         "node_modules/@octokit/auth-token": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
-            "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
             "dev": true,
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.1.tgz",
-            "integrity": "sha512-tEDxFx8E38zF3gT7sSMDrT1tGumDgsw5yPG6BBh/X+5ClIQfMH/Yqocxz1PnHx6CHyF6pxmovUTOfZAUvQ0Lvw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.0.tgz",
+            "integrity": "sha512-YbAtMWIrbZ9FCXbLwT9wWB8TyLjq9mxpKdgB3dUNxQcIVTf9hJ70gRPwAcqGZdY6WdJPZ0I7jLaaNDCiloGN2A==",
             "dev": true,
             "dependencies": {
-                "@octokit/auth-token": "^3.0.0",
-                "@octokit/graphql": "^5.0.0",
-                "@octokit/request": "^6.0.0",
-                "@octokit/request-error": "^3.0.0",
-                "@octokit/types": "^9.0.0",
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.0.0",
+                "@octokit/request": "^8.0.2",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^11.0.0",
                 "before-after-hook": "^2.2.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.5.tgz",
-            "integrity": "sha512-LG4o4HMY1Xoaec87IqQ41TQ+glvIeTKqfjkCEmt5AIwDZJwQeVZFIEYXrYY6yLwK+pAScb9Gj4q+Nz2qSw1roA==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
+            "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^9.0.0",
+                "@octokit/types": "^11.0.0",
                 "is-plain-object": "^5.0.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/endpoint/node_modules/is-plain-object": {
@@ -3660,102 +3660,101 @@
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
-            "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.1.tgz",
+            "integrity": "sha512-T5S3oZ1JOE58gom6MIcrgwZXzTaxRnxBso58xhozxHpOqSTgDS6YNeEUvZ/kRvXgPrRz/KHnZhtb7jUMRi9E6w==",
             "dev": true,
             "dependencies": {
-                "@octokit/request": "^6.0.0",
-                "@octokit/types": "^9.0.0",
+                "@octokit/request": "^8.0.1",
+                "@octokit/types": "^11.0.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/openapi-types": {
-            "version": "17.2.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
-            "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ==",
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+            "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
             "dev": true
         },
         "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.0.0.tgz",
-            "integrity": "sha512-NNm6DlYBEyKs9OZvy2Ax9YKn7e0/G7js+/I80icBTHUf6kB/nfaZkdXOF1Z32OaB+LDH6GIYpdYC3Bm3vwX5Ow==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-8.0.0.tgz",
+            "integrity": "sha512-2xZ+baZWUg+qudVXnnvXz7qfrTmDeYPCzangBVq/1gXxii/OiS//4shJp9dnCCvj1x+JAm9ji1Egwm1BA47lPQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/tsconfig": "^1.0.2",
-                "@octokit/types": "^9.2.3"
+                "@octokit/types": "^11.0.0"
             },
             "engines": {
                 "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=4"
+                "@octokit/core": ">=5"
             }
         },
         "node_modules/@octokit/plugin-retry": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-5.0.2.tgz",
-            "integrity": "sha512-/Z7rWLCfjwmaVdyFuMkZoAnhfrvYgtvDrbO2d6lv7XrvJa8gFGB5tLUMngfuyMBfDCc5B9+EVu7IkQx5ebVlMg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.0.0.tgz",
+            "integrity": "sha512-a1/A4A+PB1QoAHQfLJxGHhLfSAT03bR1jJz3GgQJZvty2ozawFWs93MiBQXO7SL2YbO7CIq0Goj4qLOBj8JeMQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^9.0.0",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^11.0.0",
                 "bottleneck": "^2.15.3"
             },
             "engines": {
                 "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=3"
+                "@octokit/core": ">=5"
             }
         },
         "node_modules/@octokit/plugin-throttling": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.0.1.tgz",
-            "integrity": "sha512-C5h2lT+LEF4SqmbB1RbMn1PhBlHKkZoqMGS39woJr0XJ+getmOcUvrytTtS4NOn1zh/iT1ByRWYwwmFYznv83w==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-7.0.0.tgz",
+            "integrity": "sha512-KL2k/d0uANc8XqP5S64YcNFCudR3F5AaKO39XWdUtlJIjT9Ni79ekWJ6Kj5xvAw87udkOMEPcVf9xEge2+ahew==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^9.0.0",
+                "@octokit/types": "^11.0.0",
                 "bottleneck": "^2.15.3"
             },
             "engines": {
                 "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": "^4.0.0"
+                "@octokit/core": "^5.0.0"
             }
         },
         "node_modules/@octokit/request": {
-            "version": "6.2.5",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.5.tgz",
-            "integrity": "sha512-z83E8UIlPNaJUsXpjD8E0V5o/5f+vJJNbNcBwVZsX3/vC650U41cOkTLjq4PKk9BYonQGOnx7N17gvLyNjgGcQ==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.1.tgz",
+            "integrity": "sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/endpoint": "^7.0.0",
-                "@octokit/request-error": "^3.0.0",
-                "@octokit/types": "^9.0.0",
+                "@octokit/endpoint": "^9.0.0",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^11.1.0",
                 "is-plain-object": "^5.0.0",
-                "node-fetch": "^2.6.7",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/request-error": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
-            "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.0.tgz",
+            "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^9.0.0",
+                "@octokit/types": "^11.0.0",
                 "deprecation": "^2.0.0",
                 "once": "^1.4.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/request/node_modules/is-plain-object": {
@@ -3767,19 +3766,13 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/@octokit/tsconfig": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-            "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
-            "dev": true
-        },
         "node_modules/@octokit/types": {
-            "version": "9.2.3",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
-            "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
+            "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/openapi-types": "^17.2.0"
+                "@octokit/openapi-types": "^18.0.0"
             }
         },
         "node_modules/@pkgjs/parseargs": {
@@ -3832,9 +3825,9 @@
             }
         },
         "node_modules/@pnpm/config.env-replace": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.0.0.tgz",
-            "integrity": "sha512-ZVPVDi1E8oeXlYqkGRtX0CkzLTwE2zt62bjWaWKaAvI8NZqHzlMvGeSNDpW+JB3+aKanYb4UETJOF1/CxGPemA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+            "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
             "dev": true,
             "engines": {
                 "node": ">=12.22.0"
@@ -3853,12 +3846,12 @@
             }
         },
         "node_modules/@pnpm/npm-conf": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.1.0.tgz",
-            "integrity": "sha512-Oe6ntvgsMTE3hDIqy6sajqHF+MnzJrOF06qC2QSiUEybLL7cp6tjoKUa32gpd9+KPVl4QyMs3E3nsXrx/Vdnlw==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
+            "integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
             "dev": true,
             "dependencies": {
-                "@pnpm/config.env-replace": "^1.0.0",
+                "@pnpm/config.env-replace": "^1.1.0",
                 "@pnpm/network.ca-file": "^1.0.1",
                 "config-chain": "^1.1.11"
             },
@@ -4658,70 +4651,6 @@
                 "semantic-release": ">=18.0.0"
             }
         },
-        "node_modules/@semantic-release/commit-analyzer": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-10.0.1.tgz",
-            "integrity": "sha512-9ejHzTAijYs9z246sY/dKBatmOPcd0GQ7lH4MgLCkv1q4GCiDZRkjHJkaQZXZVaK7mJybS+sH3Ng6G8i3pYMGQ==",
-            "dev": true,
-            "dependencies": {
-                "conventional-changelog-angular": "^6.0.0",
-                "conventional-commits-filter": "^3.0.0",
-                "conventional-commits-parser": "^4.0.0",
-                "debug": "^4.0.0",
-                "import-from": "^4.0.0",
-                "lodash-es": "^4.17.21",
-                "micromatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "semantic-release": ">=20.1.0"
-            }
-        },
-        "node_modules/@semantic-release/commit-analyzer/node_modules/conventional-changelog-angular": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
-            "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
-            "dev": true,
-            "dependencies": {
-                "compare-func": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@semantic-release/commit-analyzer/node_modules/conventional-commits-filter": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
-            "integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
-            "dev": true,
-            "dependencies": {
-                "lodash.ismatch": "^4.4.0",
-                "modify-values": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@semantic-release/commit-analyzer/node_modules/conventional-commits-parser": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-4.0.0.tgz",
-            "integrity": "sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg==",
-            "dev": true,
-            "dependencies": {
-                "is-text-path": "^1.0.1",
-                "JSONStream": "^1.3.5",
-                "meow": "^8.1.2",
-                "split2": "^3.2.2"
-            },
-            "bin": {
-                "conventional-commits-parser": "cli.js"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@semantic-release/error": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
@@ -4771,724 +4700,6 @@
             },
             "peerDependencies": {
                 "semantic-release": ">=18.0.0"
-            }
-        },
-        "node_modules/@semantic-release/github": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.0.2.tgz",
-            "integrity": "sha512-FDwR9Tkz14MR/HF6srbHDuqLPUI0GmPgn4tkjfPi45/1oZedqEXC3TqSHK3+ykJmWj1sXgs94zwGI10VR5o6kg==",
-            "dev": true,
-            "dependencies": {
-                "@octokit/core": "^4.2.1",
-                "@octokit/plugin-paginate-rest": "^7.0.0",
-                "@octokit/plugin-retry": "^5.0.0",
-                "@octokit/plugin-throttling": "^6.0.0",
-                "@semantic-release/error": "^3.0.0",
-                "aggregate-error": "^4.0.1",
-                "debug": "^4.3.4",
-                "dir-glob": "^3.0.1",
-                "globby": "^13.1.4",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.0",
-                "issue-parser": "^6.0.0",
-                "lodash-es": "^4.17.21",
-                "mime": "^3.0.0",
-                "p-filter": "^3.0.0",
-                "url-join": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "semantic-release": ">=20.1.0"
-            }
-        },
-        "node_modules/@semantic-release/github/node_modules/agent-base": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@semantic-release/github/node_modules/aggregate-error": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
-            "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-            "dev": true,
-            "dependencies": {
-                "clean-stack": "^4.0.0",
-                "indent-string": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/github/node_modules/clean-stack": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-            "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-            "dev": true,
-            "dependencies": {
-                "escape-string-regexp": "5.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/github/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/github/node_modules/globby": {
-            "version": "13.2.2",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-            "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-            "dev": true,
-            "dependencies": {
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.3.0",
-                "ignore": "^5.2.4",
-                "merge2": "^1.4.1",
-                "slash": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/github/node_modules/http-proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@semantic-release/github/node_modules/https-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@semantic-release/github/node_modules/indent-string": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-            "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/github/node_modules/slash": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-            "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm": {
-            "version": "10.0.2",
-            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-10.0.2.tgz",
-            "integrity": "sha512-Mo0XoBza4pUapxiBhLLYXeSZ9tkuHDUd/WvMbpilwuPRfJDnQXMqx5tBVon8d2mBk8JXmXpqB+ExhlWJmVT40A==",
-            "dev": true,
-            "dependencies": {
-                "@semantic-release/error": "^3.0.0",
-                "aggregate-error": "^4.0.1",
-                "execa": "^7.0.0",
-                "fs-extra": "^11.0.0",
-                "lodash-es": "^4.17.21",
-                "nerf-dart": "^1.0.0",
-                "normalize-url": "^8.0.0",
-                "npm": "^9.5.0",
-                "rc": "^1.2.8",
-                "read-pkg": "^7.0.0",
-                "registry-auth-token": "^5.0.0",
-                "semver": "^7.1.2",
-                "tempy": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "semantic-release": ">=20.1.0"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/aggregate-error": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
-            "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-            "dev": true,
-            "dependencies": {
-                "clean-stack": "^4.0.0",
-                "indent-string": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/clean-stack": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-            "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-            "dev": true,
-            "dependencies": {
-                "escape-string-regexp": "5.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/crypto-random-string": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
-            "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
-            "dev": true,
-            "dependencies": {
-                "type-fest": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/crypto-random-string/node_modules/type-fest": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/execa": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
-            "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.1",
-                "human-signals": "^4.3.0",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^3.0.7",
-                "strip-final-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/hosted-git-info": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/human-signals": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-            "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=14.18.0"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/indent-string": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-            "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/is-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-            "dev": true,
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/mimic-fn": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/normalize-package-data": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-            "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-            "dev": true,
-            "dependencies": {
-                "hosted-git-info": "^4.0.1",
-                "is-core-module": "^2.5.0",
-                "semver": "^7.3.4",
-                "validate-npm-package-license": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/npm-run-path": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-            "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/onetime": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-            "dev": true,
-            "dependencies": {
-                "mimic-fn": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/read-pkg": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
-            "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
-            "dev": true,
-            "dependencies": {
-                "@types/normalize-package-data": "^2.4.1",
-                "normalize-package-data": "^3.0.2",
-                "parse-json": "^5.2.0",
-                "type-fest": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/strip-final-newline": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/temp-dir": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
-            "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
-            "dev": true,
-            "engines": {
-                "node": ">=14.16"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/tempy": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
-            "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
-            "dev": true,
-            "dependencies": {
-                "is-stream": "^3.0.0",
-                "temp-dir": "^3.0.0",
-                "type-fest": "^2.12.2",
-                "unique-string": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/type-fest": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/unique-string": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
-            "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
-            "dev": true,
-            "dependencies": {
-                "crypto-random-string": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/npm/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
-        },
-        "node_modules/@semantic-release/release-notes-generator": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-11.0.1.tgz",
-            "integrity": "sha512-4deWsiY4Rg80oc9Ms11N20BIDgYkPMys4scNYQpi2Njdrtw5Z55nXKNsUN3kn6Sy/nI9dqqbp5L63TL4luI5Bw==",
-            "dev": true,
-            "dependencies": {
-                "conventional-changelog-angular": "^5.0.0",
-                "conventional-changelog-writer": "^5.0.0",
-                "conventional-commits-filter": "^2.0.0",
-                "conventional-commits-parser": "^3.2.3",
-                "debug": "^4.0.0",
-                "get-stream": "^6.0.0",
-                "import-from": "^4.0.0",
-                "into-stream": "^7.0.0",
-                "lodash-es": "^4.17.21",
-                "read-pkg-up": "^9.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "semantic-release": ">=20.1.0"
-            }
-        },
-        "node_modules/@semantic-release/release-notes-generator/node_modules/find-up": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-            "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-            "dev": true,
-            "dependencies": {
-                "locate-path": "^7.1.0",
-                "path-exists": "^5.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/release-notes-generator/node_modules/hosted-git-info": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@semantic-release/release-notes-generator/node_modules/locate-path": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-            "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-            "dev": true,
-            "dependencies": {
-                "p-locate": "^6.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/release-notes-generator/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@semantic-release/release-notes-generator/node_modules/normalize-package-data": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-            "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-            "dev": true,
-            "dependencies": {
-                "hosted-git-info": "^4.0.1",
-                "is-core-module": "^2.5.0",
-                "semver": "^7.3.4",
-                "validate-npm-package-license": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@semantic-release/release-notes-generator/node_modules/p-limit": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-            "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-            "dev": true,
-            "dependencies": {
-                "yocto-queue": "^1.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/release-notes-generator/node_modules/p-locate": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-            "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-            "dev": true,
-            "dependencies": {
-                "p-limit": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/release-notes-generator/node_modules/path-exists": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-            "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-            "dev": true,
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            }
-        },
-        "node_modules/@semantic-release/release-notes-generator/node_modules/read-pkg": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
-            "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
-            "dev": true,
-            "dependencies": {
-                "@types/normalize-package-data": "^2.4.1",
-                "normalize-package-data": "^3.0.2",
-                "parse-json": "^5.2.0",
-                "type-fest": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/release-notes-generator/node_modules/read-pkg-up": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
-            "integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
-            "dev": true,
-            "dependencies": {
-                "find-up": "^6.3.0",
-                "read-pkg": "^7.1.0",
-                "type-fest": "^2.5.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/release-notes-generator/node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@semantic-release/release-notes-generator/node_modules/type-fest": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/release-notes-generator/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
-        },
-        "node_modules/@semantic-release/release-notes-generator/node_modules/yocto-queue": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-            "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@sinclair/typebox": {
@@ -11489,16 +10700,15 @@
             }
         },
         "node_modules/conventional-changelog-angular": {
-            "version": "5.0.13",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
-            "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
+            "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
             "dev": true,
             "dependencies": {
-                "compare-func": "^2.0.0",
-                "q": "^1.5.1"
+                "compare-func": "^2.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=16"
             }
         },
         "node_modules/conventional-changelog-conventionalcommits": {
@@ -11514,59 +10724,152 @@
             }
         },
         "node_modules/conventional-changelog-writer": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
-            "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-6.0.1.tgz",
+            "integrity": "sha512-359t9aHorPw+U+nHzUXHS5ZnPBOizRxfQsWT5ZDHBfvfxQOAik+yfuhKXG66CN5LEWPpMNnIMHUTCKeYNprvHQ==",
             "dev": true,
             "dependencies": {
-                "conventional-commits-filter": "^2.0.7",
-                "dateformat": "^3.0.0",
+                "conventional-commits-filter": "^3.0.0",
+                "dateformat": "^3.0.3",
                 "handlebars": "^4.7.7",
                 "json-stringify-safe": "^5.0.1",
-                "lodash": "^4.17.15",
-                "meow": "^8.0.0",
-                "semver": "^6.0.0",
-                "split": "^1.0.0",
-                "through2": "^4.0.0"
+                "meow": "^8.1.2",
+                "semver": "^7.0.0",
+                "split": "^1.0.1"
             },
             "bin": {
                 "conventional-changelog-writer": "cli.js"
             },
             "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/conventional-changelog-writer/node_modules/hosted-git-info": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "engines": {
                 "node": ">=10"
             }
         },
+        "node_modules/conventional-changelog-writer/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-changelog-writer/node_modules/meow": {
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+            "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+            "dev": true,
+            "dependencies": {
+                "@types/minimist": "^1.2.0",
+                "camelcase-keys": "^6.2.2",
+                "decamelize-keys": "^1.1.0",
+                "hard-rejection": "^2.1.0",
+                "minimist-options": "4.1.0",
+                "normalize-package-data": "^3.0.0",
+                "read-pkg-up": "^7.0.1",
+                "redent": "^3.0.0",
+                "trim-newlines": "^3.0.0",
+                "type-fest": "^0.18.0",
+                "yargs-parser": "^20.2.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/conventional-changelog-writer/node_modules/normalize-package-data": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+            "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+            "dev": true,
+            "dependencies": {
+                "hosted-git-info": "^4.0.1",
+                "is-core-module": "^2.5.0",
+                "semver": "^7.3.4",
+                "validate-npm-package-license": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-changelog-writer/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-changelog-writer/node_modules/type-fest": {
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+            "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/conventional-changelog-writer/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
+        },
         "node_modules/conventional-commits-filter": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
-            "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
+            "integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
             "dev": true,
             "dependencies": {
                 "lodash.ismatch": "^4.4.0",
-                "modify-values": "^1.0.0"
+                "modify-values": "^1.0.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14"
             }
         },
         "node_modules/conventional-commits-parser": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
-            "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
+            "integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
             "dev": true,
             "dependencies": {
-                "is-text-path": "^1.0.1",
-                "JSONStream": "^1.0.4",
-                "lodash": "^4.17.15",
-                "meow": "^8.0.0",
-                "split2": "^3.0.0",
-                "through2": "^4.0.0"
+                "is-text-path": "^2.0.0",
+                "JSONStream": "^1.3.5",
+                "meow": "^12.0.1",
+                "split2": "^4.0.0"
             },
             "bin": {
-                "conventional-commits-parser": "cli.js"
+                "conventional-commits-parser": "cli.mjs"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=16"
             }
         },
         "node_modules/convert-source-map": {
@@ -16222,15 +15525,15 @@
             }
         },
         "node_modules/is-text-path": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-            "integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+            "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
             "dev": true,
             "dependencies": {
-                "text-extensions": "^1.0.0"
+                "text-extensions": "^2.0.0"
             },
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=8"
             }
         },
         "node_modules/is-typed-array": {
@@ -18576,101 +17879,16 @@
             }
         },
         "node_modules/meow": {
-            "version": "8.1.2",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
-            "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+            "version": "12.1.1",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+            "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
             "dev": true,
-            "dependencies": {
-                "@types/minimist": "^1.2.0",
-                "camelcase-keys": "^6.2.2",
-                "decamelize-keys": "^1.1.0",
-                "hard-rejection": "^2.1.0",
-                "minimist-options": "4.1.0",
-                "normalize-package-data": "^3.0.0",
-                "read-pkg-up": "^7.0.1",
-                "redent": "^3.0.0",
-                "trim-newlines": "^3.0.0",
-                "type-fest": "^0.18.0",
-                "yargs-parser": "^20.2.3"
-            },
             "engines": {
-                "node": ">=10"
+                "node": ">=16.10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/meow/node_modules/hosted-git-info": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/meow/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/meow/node_modules/normalize-package-data": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-            "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-            "dev": true,
-            "dependencies": {
-                "hosted-git-info": "^4.0.1",
-                "is-core-module": "^2.5.0",
-                "semver": "^7.3.4",
-                "validate-npm-package-license": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/meow/node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/meow/node_modules/type-fest": {
-            "version": "0.18.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-            "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/meow/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
         },
         "node_modules/merge-descriptors": {
             "version": "1.0.1",
@@ -19664,15 +18882,17 @@
             }
         },
         "node_modules/npm": {
-            "version": "9.6.2",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-9.6.2.tgz",
-            "integrity": "sha512-TnXoXhlFkH/9wI4+aXSq0aPLwKG7Ge17t1ME4/rQt+0DZWQCRk9PwhBuX/shqdUiHeKicSLSkzWx+QZgTRE+/A==",
+            "version": "9.8.1",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.1.tgz",
+            "integrity": "sha512-AfDvThQzsIXhYgk9zhbk5R+lh811lKkLAeQMMhSypf1BM7zUafeIIBzMzespeuVEJ0+LvY36oRQYf7IKLzU3rw==",
             "bundleDependencies": [
                 "@isaacs/string-locale-compare",
                 "@npmcli/arborist",
                 "@npmcli/config",
+                "@npmcli/fs",
                 "@npmcli/map-workspaces",
                 "@npmcli/package-json",
+                "@npmcli/promise-spawn",
                 "@npmcli/run-script",
                 "abbrev",
                 "archy",
@@ -19723,10 +18943,10 @@
                 "proc-log",
                 "qrcode-terminal",
                 "read",
-                "read-package-json",
-                "read-package-json-fast",
                 "semver",
+                "sigstore",
                 "ssri",
+                "supports-color",
                 "tar",
                 "text-table",
                 "tiny-relative-date",
@@ -19738,71 +18958,73 @@
             "dev": true,
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^6.2.5",
-                "@npmcli/config": "^6.1.4",
-                "@npmcli/map-workspaces": "^3.0.2",
-                "@npmcli/package-json": "^3.0.0",
-                "@npmcli/run-script": "^6.0.0",
+                "@npmcli/arborist": "^6.3.0",
+                "@npmcli/config": "^6.2.1",
+                "@npmcli/fs": "^3.1.0",
+                "@npmcli/map-workspaces": "^3.0.4",
+                "@npmcli/package-json": "^4.0.1",
+                "@npmcli/promise-spawn": "^6.0.2",
+                "@npmcli/run-script": "^6.0.2",
                 "abbrev": "^2.0.0",
                 "archy": "~1.0.0",
-                "cacache": "^17.0.4",
-                "chalk": "^4.1.2",
+                "cacache": "^17.1.3",
+                "chalk": "^5.3.0",
                 "ci-info": "^3.8.0",
                 "cli-columns": "^4.0.0",
                 "cli-table3": "^0.6.3",
                 "columnify": "^1.6.0",
                 "fastest-levenshtein": "^1.0.16",
-                "fs-minipass": "^3.0.1",
-                "glob": "^8.1.0",
-                "graceful-fs": "^4.2.10",
+                "fs-minipass": "^3.0.2",
+                "glob": "^10.2.7",
+                "graceful-fs": "^4.2.11",
                 "hosted-git-info": "^6.1.1",
-                "ini": "^3.0.1",
+                "ini": "^4.1.1",
                 "init-package-json": "^5.0.0",
                 "is-cidr": "^4.0.2",
                 "json-parse-even-better-errors": "^3.0.0",
                 "libnpmaccess": "^7.0.2",
-                "libnpmdiff": "^5.0.13",
-                "libnpmexec": "^5.0.13",
-                "libnpmfund": "^4.0.13",
+                "libnpmdiff": "^5.0.19",
+                "libnpmexec": "^6.0.3",
+                "libnpmfund": "^4.0.19",
                 "libnpmhook": "^9.0.3",
-                "libnpmorg": "^5.0.3",
-                "libnpmpack": "^5.0.13",
-                "libnpmpublish": "^7.1.2",
+                "libnpmorg": "^5.0.4",
+                "libnpmpack": "^5.0.19",
+                "libnpmpublish": "^7.5.0",
                 "libnpmsearch": "^6.0.2",
                 "libnpmteam": "^5.0.3",
                 "libnpmversion": "^4.0.2",
-                "make-fetch-happen": "^11.0.3",
-                "minimatch": "^6.2.0",
-                "minipass": "^4.2.4",
+                "make-fetch-happen": "^11.1.1",
+                "minimatch": "^9.0.3",
+                "minipass": "^5.0.0",
                 "minipass-pipeline": "^1.2.4",
                 "ms": "^2.1.2",
-                "node-gyp": "^9.3.1",
-                "nopt": "^7.0.0",
-                "npm-audit-report": "^4.0.0",
-                "npm-install-checks": "^6.0.0",
+                "node-gyp": "^9.4.0",
+                "nopt": "^7.2.0",
+                "npm-audit-report": "^5.0.0",
+                "npm-install-checks": "^6.1.1",
                 "npm-package-arg": "^10.1.0",
                 "npm-pick-manifest": "^8.0.1",
                 "npm-profile": "^7.0.1",
-                "npm-registry-fetch": "^14.0.3",
+                "npm-registry-fetch": "^14.0.5",
                 "npm-user-validate": "^2.0.0",
                 "npmlog": "^7.0.1",
                 "p-map": "^4.0.0",
-                "pacote": "^15.1.1",
-                "parse-conflict-json": "^3.0.0",
+                "pacote": "^15.2.0",
+                "parse-conflict-json": "^3.0.1",
                 "proc-log": "^3.0.0",
                 "qrcode-terminal": "^0.12.0",
-                "read": "^2.0.0",
-                "read-package-json": "^6.0.0",
-                "read-package-json-fast": "^3.0.2",
-                "semver": "^7.3.8",
-                "ssri": "^10.0.1",
-                "tar": "^6.1.13",
+                "read": "^2.1.0",
+                "semver": "^7.5.4",
+                "sigstore": "^1.7.0",
+                "ssri": "^10.0.4",
+                "supports-color": "^9.4.0",
+                "tar": "^6.1.15",
                 "text-table": "~0.2.0",
                 "tiny-relative-date": "^1.3.0",
                 "treeverse": "^3.0.0",
                 "validate-npm-package-name": "^5.0.0",
-                "which": "^3.0.0",
-                "write-file-atomic": "^5.0.0"
+                "which": "^3.0.1",
+                "write-file-atomic": "^5.0.1"
             },
             "bin": {
                 "npm": "bin/npm-cli.js",
@@ -19938,11 +19160,72 @@
                 "node": ">=0.1.90"
             }
         },
-        "node_modules/npm/node_modules/@gar/promisify": {
-            "version": "1.1.3",
+        "node_modules/npm/node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
+        },
+        "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
         },
         "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
             "version": "1.1.0",
@@ -19951,7 +19234,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/@npmcli/arborist": {
-            "version": "6.2.5",
+            "version": "6.3.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -19963,7 +19246,7 @@
                 "@npmcli/metavuln-calculator": "^5.0.0",
                 "@npmcli/name-from-folder": "^2.0.0",
                 "@npmcli/node-gyp": "^3.0.0",
-                "@npmcli/package-json": "^3.0.0",
+                "@npmcli/package-json": "^4.0.0",
                 "@npmcli/query": "^3.0.0",
                 "@npmcli/run-script": "^6.0.0",
                 "bin-links": "^4.0.1",
@@ -19972,7 +19255,7 @@
                 "hosted-git-info": "^6.1.1",
                 "json-parse-even-better-errors": "^3.0.0",
                 "json-stringify-nice": "^1.1.4",
-                "minimatch": "^6.1.6",
+                "minimatch": "^9.0.0",
                 "nopt": "^7.0.0",
                 "npm-install-checks": "^6.0.0",
                 "npm-package-arg": "^10.1.0",
@@ -19983,12 +19266,12 @@
                 "parse-conflict-json": "^3.0.0",
                 "proc-log": "^3.0.0",
                 "promise-all-reject-late": "^1.0.0",
-                "promise-call-limit": "^1.0.1",
+                "promise-call-limit": "^1.0.2",
                 "read-package-json-fast": "^3.0.2",
                 "semver": "^7.3.7",
                 "ssri": "^10.0.1",
                 "treeverse": "^3.0.0",
-                "walk-up-path": "^1.0.0"
+                "walk-up-path": "^3.0.1"
             },
             "bin": {
                 "arborist": "bin/index.js"
@@ -19998,18 +19281,19 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/config": {
-            "version": "6.1.4",
+            "version": "6.2.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/map-workspaces": "^3.0.2",
-                "ini": "^3.0.0",
+                "ci-info": "^3.8.0",
+                "ini": "^4.1.0",
                 "nopt": "^7.0.0",
                 "proc-log": "^3.0.0",
                 "read-package-json-fast": "^3.0.2",
                 "semver": "^7.3.5",
-                "walk-up-path": "^1.0.0"
+                "walk-up-path": "^3.0.1"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -20040,14 +19324,13 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/git": {
-            "version": "4.0.3",
+            "version": "4.1.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/promise-spawn": "^6.0.0",
                 "lru-cache": "^7.4.4",
-                "mkdirp": "^1.0.4",
                 "npm-pick-manifest": "^8.0.0",
                 "proc-log": "^3.0.0",
                 "promise-inflight": "^1.0.1",
@@ -20076,14 +19359,14 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-            "version": "3.0.2",
+            "version": "3.0.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/name-from-folder": "^2.0.0",
-                "glob": "^8.0.1",
-                "minimatch": "^6.1.6",
+                "glob": "^10.2.2",
+                "minimatch": "^9.0.0",
                 "read-package-json-fast": "^3.0.0"
             },
             "engines": {
@@ -20091,7 +19374,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-            "version": "5.0.0",
+            "version": "5.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -20103,19 +19386,6 @@
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/@npmcli/move-file": {
-            "version": "2.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "mkdirp": "^1.0.4",
-                "rimraf": "^3.0.2"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/@npmcli/name-from-folder": {
@@ -20137,12 +19407,18 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/package-json": {
-            "version": "3.0.0",
+            "version": "4.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "json-parse-even-better-errors": "^3.0.0"
+                "@npmcli/git": "^4.1.0",
+                "glob": "^10.2.2",
+                "hosted-git-info": "^6.1.1",
+                "json-parse-even-better-errors": "^3.0.0",
+                "normalize-package-data": "^5.0.0",
+                "proc-log": "^3.0.0",
+                "semver": "^7.5.3"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -20173,7 +19449,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/run-script": {
-            "version": "6.0.0",
+            "version": "6.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -20188,11 +19464,34 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
+        "node_modules/npm/node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
             "version": "0.1.0",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/tuf": {
+            "version": "1.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/protobuf-specs": "^0.1.0",
+                "tuf-js": "^1.1.7"
+            },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
@@ -20206,13 +19505,23 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/npm/node_modules/@tufjs/models": {
+        "node_modules/npm/node_modules/@tufjs/canonical-json": {
             "version": "1.0.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/@tufjs/models": {
+            "version": "1.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
             "dependencies": {
-                "minimatch": "^6.1.0"
+                "@tufjs/canonical-json": "1.0.0",
+                "minimatch": "^9.0.0"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -20354,7 +19663,7 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/bin-links": {
-            "version": "4.0.1",
+            "version": "4.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -20420,21 +19729,20 @@
             }
         },
         "node_modules/npm/node_modules/cacache": {
-            "version": "17.0.4",
+            "version": "17.1.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/fs": "^3.1.0",
                 "fs-minipass": "^3.0.0",
-                "glob": "^8.0.1",
+                "glob": "^10.2.2",
                 "lru-cache": "^7.7.1",
-                "minipass": "^4.0.0",
+                "minipass": "^5.0.0",
                 "minipass-collect": "^1.0.2",
                 "minipass-flush": "^1.0.5",
                 "minipass-pipeline": "^1.2.4",
                 "p-map": "^4.0.0",
-                "promise-inflight": "^1.0.1",
                 "ssri": "^10.0.0",
                 "tar": "^6.1.11",
                 "unique-filename": "^3.0.0"
@@ -20444,16 +19752,12 @@
             }
         },
         "node_modules/npm/node_modules/chalk": {
-            "version": "4.1.2",
+            "version": "5.3.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
             "engines": {
-                "node": ">=10"
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -20608,6 +19912,35 @@
             "inBundle": true,
             "license": "ISC"
         },
+        "node_modules/npm/node_modules/cross-spawn": {
+            "version": "7.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
+            "version": "2.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/npm/node_modules/cssesc": {
             "version": "3.0.0",
             "dev": true,
@@ -20679,6 +20012,12 @@
                 "node": ">=0.3.1"
             }
         },
+        "node_modules/npm/node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
         "node_modules/npm/node_modules/emoji-regex": {
             "version": "8.0.0",
             "dev": true,
@@ -20728,6 +20067,12 @@
                 "node": ">=0.8.x"
             }
         },
+        "node_modules/npm/node_modules/exponential-backoff": {
+            "version": "3.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/npm/node_modules/fastest-levenshtein": {
             "version": "1.0.16",
             "dev": true,
@@ -20737,13 +20082,29 @@
                 "node": ">= 4.9.1"
             }
         },
-        "node_modules/npm/node_modules/fs-minipass": {
-            "version": "3.0.1",
+        "node_modules/npm/node_modules/foreground-child": {
+            "version": "3.1.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "minipass": "^4.0.0"
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/fs-minipass": {
+            "version": "3.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^5.0.0"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -20762,7 +20123,7 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/gauge": {
-            "version": "5.0.0",
+            "version": "5.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -20771,7 +20132,7 @@
                 "color-support": "^1.1.3",
                 "console-control-strings": "^1.1.0",
                 "has-unicode": "^2.0.1",
-                "signal-exit": "^3.0.7",
+                "signal-exit": "^4.0.1",
                 "string-width": "^4.2.3",
                 "strip-ansi": "^6.0.1",
                 "wide-align": "^1.1.5"
@@ -20781,38 +20142,29 @@
             }
         },
         "node_modules/npm/node_modules/glob": {
-            "version": "8.1.0",
+            "version": "10.2.7",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^2.0.3",
+                "minimatch": "^9.0.1",
+                "minipass": "^5.0.0 || ^6.0.2",
+                "path-scurry": "^1.7.0"
+            },
+            "bin": {
+                "glob": "dist/cjs/src/bin.js"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/npm/node_modules/glob/node_modules/minimatch": {
-            "version": "5.1.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/npm/node_modules/graceful-fs": {
-            "version": "4.2.10",
+            "version": "4.2.11",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
@@ -20827,15 +20179,6 @@
             },
             "engines": {
                 "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/npm/node_modules/has-flag": {
-            "version": "4.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/npm/node_modules/has-unicode": {
@@ -20932,12 +20275,12 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/npm/node_modules/ignore-walk": {
-            "version": "6.0.1",
+            "version": "6.0.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "minimatch": "^6.1.6"
+                "minimatch": "^9.0.0"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -20961,12 +20304,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/npm/node_modules/infer-owner": {
-            "version": "1.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
         "node_modules/npm/node_modules/inflight": {
             "version": "1.0.6",
             "dev": true,
@@ -20984,12 +20321,12 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/ini": {
-            "version": "3.0.1",
+            "version": "4.1.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/npm/node_modules/init-package-json": {
@@ -21038,7 +20375,7 @@
             }
         },
         "node_modules/npm/node_modules/is-core-module": {
-            "version": "2.11.0",
+            "version": "2.12.1",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -21070,6 +20407,24 @@
             "inBundle": true,
             "license": "ISC"
         },
+        "node_modules/npm/node_modules/jackspeak": {
+            "version": "2.2.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
         "node_modules/npm/node_modules/json-parse-even-better-errors": {
             "version": "3.0.0",
             "dev": true,
@@ -21098,7 +20453,7 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/just-diff": {
-            "version": "5.2.0",
+            "version": "6.0.2",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -21123,17 +20478,17 @@
             }
         },
         "node_modules/npm/node_modules/libnpmdiff": {
-            "version": "5.0.13",
+            "version": "5.0.19",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^6.2.5",
+                "@npmcli/arborist": "^6.3.0",
                 "@npmcli/disparity-colors": "^3.0.0",
                 "@npmcli/installed-package-contents": "^2.0.2",
                 "binary-extensions": "^2.2.0",
                 "diff": "^5.1.0",
-                "minimatch": "^6.1.6",
+                "minimatch": "^9.0.0",
                 "npm-package-arg": "^10.1.0",
                 "pacote": "^15.0.8",
                 "tar": "^6.1.13"
@@ -21143,14 +20498,13 @@
             }
         },
         "node_modules/npm/node_modules/libnpmexec": {
-            "version": "5.0.13",
+            "version": "6.0.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^6.2.5",
+                "@npmcli/arborist": "^6.3.0",
                 "@npmcli/run-script": "^6.0.0",
-                "chalk": "^4.1.0",
                 "ci-info": "^3.7.1",
                 "npm-package-arg": "^10.1.0",
                 "npmlog": "^7.0.1",
@@ -21159,19 +20513,19 @@
                 "read": "^2.0.0",
                 "read-package-json-fast": "^3.0.2",
                 "semver": "^7.3.7",
-                "walk-up-path": "^1.0.0"
+                "walk-up-path": "^3.0.1"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/npm/node_modules/libnpmfund": {
-            "version": "4.0.13",
+            "version": "4.0.19",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^6.2.5"
+                "@npmcli/arborist": "^6.3.0"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -21191,7 +20545,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmorg": {
-            "version": "5.0.3",
+            "version": "5.0.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -21204,12 +20558,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmpack": {
-            "version": "5.0.13",
+            "version": "5.0.19",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^6.2.5",
+                "@npmcli/arborist": "^6.3.0",
                 "@npmcli/run-script": "^6.0.0",
                 "npm-package-arg": "^10.1.0",
                 "pacote": "^15.0.8"
@@ -21219,7 +20573,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmpublish": {
-            "version": "7.1.2",
+            "version": "7.5.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -21230,7 +20584,7 @@
                 "npm-registry-fetch": "^14.0.3",
                 "proc-log": "^3.0.0",
                 "semver": "^7.3.7",
-                "sigstore": "^1.0.0",
+                "sigstore": "^1.4.0",
                 "ssri": "^10.0.1"
             },
             "engines": {
@@ -21288,7 +20642,7 @@
             }
         },
         "node_modules/npm/node_modules/make-fetch-happen": {
-            "version": "11.0.3",
+            "version": "11.1.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -21300,7 +20654,7 @@
                 "https-proxy-agent": "^5.0.0",
                 "is-lambda": "^1.0.1",
                 "lru-cache": "^7.7.1",
-                "minipass": "^4.0.0",
+                "minipass": "^5.0.0",
                 "minipass-fetch": "^3.0.0",
                 "minipass-flush": "^1.0.5",
                 "minipass-pipeline": "^1.2.4",
@@ -21314,7 +20668,7 @@
             }
         },
         "node_modules/npm/node_modules/minimatch": {
-            "version": "6.2.0",
+            "version": "9.0.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -21322,14 +20676,14 @@
                 "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/npm/node_modules/minipass": {
-            "version": "4.2.4",
+            "version": "5.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -21362,12 +20716,12 @@
             }
         },
         "node_modules/npm/node_modules/minipass-fetch": {
-            "version": "3.0.1",
+            "version": "3.0.3",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "minipass": "^4.0.0",
+                "minipass": "^5.0.0",
                 "minipass-sized": "^1.0.3",
                 "minizlib": "^2.1.2"
             },
@@ -21534,15 +20888,16 @@
             }
         },
         "node_modules/npm/node_modules/node-gyp": {
-            "version": "9.3.1",
+            "version": "9.4.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.0",
+                "exponential-backoff": "^3.1.1",
                 "glob": "^7.1.4",
                 "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^10.0.3",
+                "make-fetch-happen": "^11.0.3",
                 "nopt": "^6.0.0",
                 "npmlog": "^6.0.0",
                 "rimraf": "^3.0.2",
@@ -21555,19 +20910,6 @@
             },
             "engines": {
                 "node": "^12.13 || ^14.13 || >=16"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/fs": {
-            "version": "2.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@gar/promisify": "^1.1.3",
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
@@ -21597,87 +20939,6 @@
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/cacache": {
-            "version": "16.1.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/fs": "^2.1.0",
-                "@npmcli/move-file": "^2.0.0",
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.1.0",
-                "glob": "^8.0.1",
-                "infer-owner": "^1.0.4",
-                "lru-cache": "^7.7.1",
-                "minipass": "^3.1.6",
-                "minipass-collect": "^1.0.2",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "mkdirp": "^1.0.4",
-                "p-map": "^4.0.0",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^3.0.2",
-                "ssri": "^9.0.0",
-                "tar": "^6.1.11",
-                "unique-filename": "^2.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/glob": {
-            "version": "8.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/minimatch": {
-            "version": "5.1.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/fs-minipass": {
-            "version": "2.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
             }
         },
         "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
@@ -21719,33 +20980,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/npm/node_modules/node-gyp/node_modules/make-fetch-happen": {
-            "version": "10.2.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "agentkeepalive": "^4.2.1",
-                "cacache": "^16.1.0",
-                "http-cache-semantics": "^4.1.0",
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "is-lambda": "^1.0.1",
-                "lru-cache": "^7.7.1",
-                "minipass": "^3.1.6",
-                "minipass-collect": "^1.0.2",
-                "minipass-fetch": "^2.0.3",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^0.6.3",
-                "promise-retry": "^2.0.1",
-                "socks-proxy-agent": "^7.0.0",
-                "ssri": "^9.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
         "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
             "version": "3.1.2",
             "dev": true,
@@ -21756,35 +20990,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/minipass": {
-            "version": "3.3.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/minipass-fetch": {
-            "version": "2.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^3.1.6",
-                "minipass-sized": "^1.0.3",
-                "minizlib": "^2.1.2"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            },
-            "optionalDependencies": {
-                "encoding": "^0.1.13"
             }
         },
         "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
@@ -21818,7 +21023,7 @@
             }
         },
         "node_modules/npm/node_modules/node-gyp/node_modules/readable-stream": {
-            "version": "3.6.1",
+            "version": "3.6.2",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -21831,41 +21036,11 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/npm/node_modules/node-gyp/node_modules/ssri": {
-            "version": "9.0.1",
+        "node_modules/npm/node_modules/node-gyp/node_modules/signal-exit": {
+            "version": "3.0.7",
             "dev": true,
             "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.1.1"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/unique-filename": {
-            "version": "2.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "unique-slug": "^3.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/node-gyp/node_modules/unique-slug": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "imurmurhash": "^0.1.4"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
+            "license": "ISC"
         },
         "node_modules/npm/node_modules/node-gyp/node_modules/which": {
             "version": "2.0.2",
@@ -21883,7 +21058,7 @@
             }
         },
         "node_modules/npm/node_modules/nopt": {
-            "version": "7.0.0",
+            "version": "7.2.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -21913,13 +21088,10 @@
             }
         },
         "node_modules/npm/node_modules/npm-audit-report": {
-            "version": "4.0.0",
+            "version": "5.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
-            "dependencies": {
-                "chalk": "^4.0.0"
-            },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
@@ -21937,7 +21109,7 @@
             }
         },
         "node_modules/npm/node_modules/npm-install-checks": {
-            "version": "6.0.0",
+            "version": "6.1.1",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
@@ -21949,7 +21121,7 @@
             }
         },
         "node_modules/npm/node_modules/npm-normalize-package-bin": {
-            "version": "3.0.0",
+            "version": "3.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -22013,13 +21185,13 @@
             }
         },
         "node_modules/npm/node_modules/npm-registry-fetch": {
-            "version": "14.0.3",
+            "version": "14.0.5",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "make-fetch-happen": "^11.0.0",
-                "minipass": "^4.0.0",
+                "minipass": "^5.0.0",
                 "minipass-fetch": "^3.0.0",
                 "minipass-json-stream": "^1.0.1",
                 "minizlib": "^2.1.2",
@@ -22079,7 +21251,7 @@
             }
         },
         "node_modules/npm/node_modules/pacote": {
-            "version": "15.1.1",
+            "version": "15.2.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -22090,7 +21262,7 @@
                 "@npmcli/run-script": "^6.0.0",
                 "cacache": "^17.0.0",
                 "fs-minipass": "^3.0.0",
-                "minipass": "^4.0.0",
+                "minipass": "^5.0.0",
                 "npm-package-arg": "^10.0.0",
                 "npm-packlist": "^7.0.0",
                 "npm-pick-manifest": "^8.0.0",
@@ -22099,7 +21271,7 @@
                 "promise-retry": "^2.0.1",
                 "read-package-json": "^6.0.0",
                 "read-package-json-fast": "^3.0.0",
-                "sigstore": "^1.0.0",
+                "sigstore": "^1.3.0",
                 "ssri": "^10.0.0",
                 "tar": "^6.1.11"
             },
@@ -22111,13 +21283,13 @@
             }
         },
         "node_modules/npm/node_modules/parse-conflict-json": {
-            "version": "3.0.0",
+            "version": "3.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "json-parse-even-better-errors": "^3.0.0",
-                "just-diff": "^5.0.1",
+                "just-diff": "^6.0.0",
                 "just-diff-apply": "^5.2.0"
             },
             "engines": {
@@ -22133,8 +21305,42 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/npm/node_modules/path-key": {
+            "version": "3.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/path-scurry": {
+            "version": "1.9.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^9.1.1",
+                "minipass": "^5.0.0 || ^6.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "9.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "14 || >=16.14"
+            }
+        },
         "node_modules/npm/node_modules/postcss-selector-parser": {
-            "version": "6.0.11",
+            "version": "6.0.13",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -22174,7 +21380,7 @@
             }
         },
         "node_modules/npm/node_modules/promise-call-limit": {
-            "version": "1.0.1",
+            "version": "1.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -22222,7 +21428,7 @@
             }
         },
         "node_modules/npm/node_modules/read": {
-            "version": "2.0.0",
+            "version": "2.1.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -22243,12 +21449,12 @@
             }
         },
         "node_modules/npm/node_modules/read-package-json": {
-            "version": "6.0.0",
+            "version": "6.0.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "glob": "^8.0.1",
+                "glob": "^10.2.2",
                 "json-parse-even-better-errors": "^3.0.0",
                 "normalize-package-data": "^5.0.0",
                 "npm-normalize-package-bin": "^3.0.0"
@@ -22271,7 +21477,7 @@
             }
         },
         "node_modules/npm/node_modules/readable-stream": {
-            "version": "4.3.0",
+            "version": "4.4.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -22352,8 +21558,22 @@
             }
         },
         "node_modules/npm/node_modules/safe-buffer": {
-            "version": "5.1.2",
+            "version": "5.2.1",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
             "inBundle": true,
             "license": "MIT"
         },
@@ -22365,7 +21585,7 @@
             "optional": true
         },
         "node_modules/npm/node_modules/semver": {
-            "version": "7.3.8",
+            "version": "7.5.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -22397,21 +21617,48 @@
             "inBundle": true,
             "license": "ISC"
         },
-        "node_modules/npm/node_modules/signal-exit": {
-            "version": "3.0.7",
+        "node_modules/npm/node_modules/shebang-command": {
+            "version": "2.0.0",
             "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/signal-exit": {
+            "version": "4.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/npm/node_modules/sigstore": {
-            "version": "1.1.1",
+            "version": "1.7.0",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/protobuf-specs": "^0.1.0",
-                "make-fetch-happen": "^11.0.1",
-                "tuf-js": "^1.0.0"
+                "@sigstore/tuf": "^1.0.1",
+                "make-fetch-happen": "^11.0.1"
             },
             "bin": {
                 "sigstore": "bin/sigstore.js"
@@ -22485,33 +21732,48 @@
             }
         },
         "node_modules/npm/node_modules/spdx-license-ids": {
-            "version": "3.0.12",
+            "version": "3.0.13",
             "dev": true,
             "inBundle": true,
             "license": "CC0-1.0"
         },
         "node_modules/npm/node_modules/ssri": {
-            "version": "10.0.1",
+            "version": "10.0.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "minipass": "^4.0.0"
+                "minipass": "^5.0.0"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/npm/node_modules/string_decoder": {
-            "version": "1.1.1",
+            "version": "1.3.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/npm/node_modules/string-width": {
+            "version": "4.2.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/string-width-cjs": {
+            "name": "string-width",
             "version": "4.2.3",
             "dev": true,
             "inBundle": true,
@@ -22537,27 +21799,40 @@
                 "node": ">=8"
             }
         },
-        "node_modules/npm/node_modules/supports-color": {
-            "version": "7.2.0",
+        "node_modules/npm/node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "has-flag": "^4.0.0"
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
                 "node": ">=8"
             }
         },
+        "node_modules/npm/node_modules/supports-color": {
+            "version": "9.4.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
         "node_modules/npm/node_modules/tar": {
-            "version": "6.1.13",
+            "version": "6.1.15",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
-                "minipass": "^4.0.0",
+                "minipass": "^5.0.0",
                 "minizlib": "^2.1.1",
                 "mkdirp": "^1.0.3",
                 "yallist": "^4.0.0"
@@ -22612,13 +21887,14 @@
             }
         },
         "node_modules/npm/node_modules/tuf-js": {
-            "version": "1.1.1",
+            "version": "1.1.7",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "@tufjs/models": "1.0.0",
-                "make-fetch-happen": "^11.0.1"
+                "@tufjs/models": "1.0.4",
+                "debug": "^4.3.4",
+                "make-fetch-happen": "^11.1.1"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -22677,7 +21953,7 @@
             }
         },
         "node_modules/npm/node_modules/walk-up-path": {
-            "version": "1.0.0",
+            "version": "3.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
@@ -22692,7 +21968,7 @@
             }
         },
         "node_modules/npm/node_modules/which": {
-            "version": "3.0.0",
+            "version": "3.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -22715,6 +21991,103 @@
                 "string-width": "^1.0.2 || 2 || 3 || 4"
             }
         },
+        "node_modules/npm/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+            "version": "6.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "5.1.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
         "node_modules/npm/node_modules/wrappy": {
             "version": "1.0.2",
             "dev": true,
@@ -22722,13 +22095,13 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/write-file-atomic": {
-            "version": "5.0.0",
+            "version": "5.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.7"
+                "signal-exit": "^4.0.1"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -24496,16 +23869,6 @@
                 "async-limiter": "~1.0.0"
             }
         },
-        "node_modules/q": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-            "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.6.0",
-                "teleport": ">=0.2.0"
-            }
-        },
         "node_modules/qs": {
             "version": "6.11.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -25820,16 +25183,16 @@
             }
         },
         "node_modules/semantic-release": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-21.1.1.tgz",
-            "integrity": "sha512-OCIazQnaCHdq1F6zfmKS0P7jZakYq0weiqW2mxUWo4H2CDnxelUoa/0Bs/dQatoHc6JFh6lG2HWpusdl93bFcw==",
+            "version": "22.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-22.0.0-beta.2.tgz",
+            "integrity": "sha512-sPdFctw9g0e0NoCsV1OMMXUQUq16aWPw9BjLvfmHfOJX6Vt/4U7pRlWpCJQXp45KYXUpNmtb1xKZCSdWrCsyng==",
             "dev": true,
             "dependencies": {
-                "@semantic-release/commit-analyzer": "^10.0.0",
+                "@semantic-release/commit-analyzer": "^11.0.0-beta.1",
                 "@semantic-release/error": "^4.0.0",
                 "@semantic-release/github": "^9.0.0",
                 "@semantic-release/npm": "^10.0.2",
-                "@semantic-release/release-notes-generator": "^11.0.0",
+                "@semantic-release/release-notes-generator": "^12.0.0-beta.1",
                 "aggregate-error": "^4.0.1",
                 "cosmiconfig": "^8.0.0",
                 "debug": "^4.0.0",
@@ -25861,6 +25224,27 @@
                 "node": ">=18"
             }
         },
+        "node_modules/semantic-release/node_modules/@semantic-release/commit-analyzer": {
+            "version": "11.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-11.0.0-beta.1.tgz",
+            "integrity": "sha512-4HOXQ09k/lnHwxQLD9y1c+b3rA2M4gWA/twJl9JuRqS1eXrEc9QJ903reN5nwEC0Y7TVpuDTd1cY90B6W9EITw==",
+            "dev": true,
+            "dependencies": {
+                "conventional-changelog-angular": "^7.0.0",
+                "conventional-commits-filter": "^3.0.0",
+                "conventional-commits-parser": "^5.0.0",
+                "debug": "^4.0.0",
+                "import-from": "^4.0.0",
+                "lodash-es": "^4.17.21",
+                "micromatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
         "node_modules/semantic-release/node_modules/@semantic-release/error": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
@@ -25868,6 +25252,120 @@
             "dev": true,
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/semantic-release/node_modules/@semantic-release/github": {
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.0.4.tgz",
+            "integrity": "sha512-kQCGFAsBErvCR6hzNuzu63cj4erQN2krm9zQlg8vl4j5X0mL0d/Ras0wmL5Gkr1TuSS2lweME7M4J5zvtDDDSA==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/core": "^5.0.0",
+                "@octokit/plugin-paginate-rest": "^8.0.0",
+                "@octokit/plugin-retry": "^6.0.0",
+                "@octokit/plugin-throttling": "^7.0.0",
+                "@semantic-release/error": "^4.0.0",
+                "aggregate-error": "^4.0.1",
+                "debug": "^4.3.4",
+                "dir-glob": "^3.0.1",
+                "globby": "^13.1.4",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.0",
+                "issue-parser": "^6.0.0",
+                "lodash-es": "^4.17.21",
+                "mime": "^3.0.0",
+                "p-filter": "^3.0.0",
+                "url-join": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
+        "node_modules/semantic-release/node_modules/@semantic-release/npm": {
+            "version": "10.0.5",
+            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-10.0.5.tgz",
+            "integrity": "sha512-cJnQ2M5pxJRwZEkb0A/+U3TG4UNmjrrLwV2PxJKljn5OPT0yJB8GzGgWbbKACayvxrT06YdTa4Amtq/piJcOIA==",
+            "dev": true,
+            "dependencies": {
+                "@semantic-release/error": "^4.0.0",
+                "aggregate-error": "^4.0.1",
+                "execa": "^8.0.0",
+                "fs-extra": "^11.0.0",
+                "lodash-es": "^4.17.21",
+                "nerf-dart": "^1.0.0",
+                "normalize-url": "^8.0.0",
+                "npm": "^9.5.0",
+                "rc": "^1.2.8",
+                "read-pkg": "^8.0.0",
+                "registry-auth-token": "^5.0.0",
+                "semver": "^7.1.2",
+                "tempy": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
+        "node_modules/semantic-release/node_modules/@semantic-release/release-notes-generator": {
+            "version": "12.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-12.0.0-beta.1.tgz",
+            "integrity": "sha512-VKkXO4FXPP/nX90/9M1vGI9oMPpKOqYdeDl7hM5dAnNa7X1gC4hE2bZC8vqojHtQaf2tHIyGHZH186F5LwNRDA==",
+            "dev": true,
+            "dependencies": {
+                "conventional-changelog-angular": "^7.0.0",
+                "conventional-changelog-writer": "^6.0.0",
+                "conventional-commits-filter": "^4.0.0",
+                "conventional-commits-parser": "^5.0.0",
+                "debug": "^4.0.0",
+                "get-stream": "^7.0.0",
+                "import-from": "^4.0.0",
+                "into-stream": "^7.0.0",
+                "lodash-es": "^4.17.21",
+                "read-pkg-up": "^10.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
+        "node_modules/semantic-release/node_modules/@semantic-release/release-notes-generator/node_modules/conventional-commits-filter": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
+            "integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/semantic-release/node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
+            "integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/agent-base": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/semantic-release/node_modules/aggregate-error": {
@@ -25896,6 +25394,33 @@
             },
             "engines": {
                 "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/crypto-random-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+            "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+            "dev": true,
+            "dependencies": {
+                "type-fest": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/crypto-random-string/node_modules/type-fest": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -25964,6 +25489,25 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/semantic-release/node_modules/globby": {
+            "version": "13.2.2",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+            "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+            "dev": true,
+            "dependencies": {
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.3.0",
+                "ignore": "^5.2.4",
+                "merge2": "^1.4.1",
+                "slash": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/semantic-release/node_modules/hosted-git-info": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.0.tgz",
@@ -25974,6 +25518,32 @@
             },
             "engines": {
                 "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/semantic-release/node_modules/http-proxy-agent": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+            "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/semantic-release/node_modules/https-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/semantic-release/node_modules/human-signals": {
@@ -26249,6 +25819,132 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/semantic-release/node_modules/semantic-release": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-21.1.1.tgz",
+            "integrity": "sha512-OCIazQnaCHdq1F6zfmKS0P7jZakYq0weiqW2mxUWo4H2CDnxelUoa/0Bs/dQatoHc6JFh6lG2HWpusdl93bFcw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@semantic-release/commit-analyzer": "^10.0.0",
+                "@semantic-release/error": "^4.0.0",
+                "@semantic-release/github": "^9.0.0",
+                "@semantic-release/npm": "^10.0.2",
+                "@semantic-release/release-notes-generator": "^11.0.0",
+                "aggregate-error": "^4.0.1",
+                "cosmiconfig": "^8.0.0",
+                "debug": "^4.0.0",
+                "env-ci": "^9.0.0",
+                "execa": "^8.0.0",
+                "figures": "^5.0.0",
+                "find-versions": "^5.1.0",
+                "get-stream": "^6.0.0",
+                "git-log-parser": "^1.2.0",
+                "hook-std": "^3.0.0",
+                "hosted-git-info": "^7.0.0",
+                "lodash-es": "^4.17.21",
+                "marked": "^5.0.0",
+                "marked-terminal": "^5.1.1",
+                "micromatch": "^4.0.2",
+                "p-each-series": "^3.0.0",
+                "p-reduce": "^3.0.0",
+                "read-pkg-up": "^10.0.0",
+                "resolve-from": "^5.0.0",
+                "semver": "^7.3.2",
+                "semver-diff": "^4.0.0",
+                "signale": "^1.2.1",
+                "yargs": "^17.5.1"
+            },
+            "bin": {
+                "semantic-release": "bin/semantic-release.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/semantic-release/node_modules/semantic-release/node_modules/@semantic-release/commit-analyzer": {
+            "version": "10.0.4",
+            "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-10.0.4.tgz",
+            "integrity": "sha512-pFGn99fn8w4/MHE0otb2A/l5kxgOuxaaauIh4u30ncoTJuqWj4hXTgEJ03REqjS+w1R2vPftSsO26WC61yOcpw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "conventional-changelog-angular": "^6.0.0",
+                "conventional-commits-filter": "^3.0.0",
+                "conventional-commits-parser": "^5.0.0",
+                "debug": "^4.0.0",
+                "import-from": "^4.0.0",
+                "lodash-es": "^4.17.21",
+                "micromatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
+        "node_modules/semantic-release/node_modules/semantic-release/node_modules/@semantic-release/release-notes-generator": {
+            "version": "11.0.7",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-11.0.7.tgz",
+            "integrity": "sha512-T09QB9ImmNx7Q6hY6YnnEbw/rEJ6a+22LBxfZq+pSAXg/OL/k0siwEm5cK4k1f9dE2Z2mPIjJKKohzUm0jbxcQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "conventional-changelog-angular": "^6.0.0",
+                "conventional-changelog-writer": "^6.0.0",
+                "conventional-commits-filter": "^4.0.0",
+                "conventional-commits-parser": "^5.0.0",
+                "debug": "^4.0.0",
+                "get-stream": "^7.0.0",
+                "import-from": "^4.0.0",
+                "into-stream": "^7.0.0",
+                "lodash-es": "^4.17.21",
+                "read-pkg-up": "^10.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
+        "node_modules/semantic-release/node_modules/semantic-release/node_modules/@semantic-release/release-notes-generator/node_modules/conventional-commits-filter": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
+            "integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/semantic-release/node_modules/semantic-release/node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
+            "integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/semantic-release/node_modules/conventional-changelog-angular": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
+            "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "compare-func": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/semantic-release/node_modules/semver": {
             "version": "7.5.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -26288,11 +25984,77 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/semantic-release/node_modules/slash": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+            "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/semantic-release/node_modules/strip-final-newline": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
             "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
             "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/temp-dir": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+            "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
+        "node_modules/semantic-release/node_modules/tempy": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+            "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+            "dev": true,
+            "dependencies": {
+                "is-stream": "^3.0.0",
+                "temp-dir": "^3.0.0",
+                "type-fest": "^2.12.2",
+                "unique-string": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/tempy/node_modules/type-fest": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/unique-string": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+            "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+            "dev": true,
+            "dependencies": {
+                "crypto-random-string": "^4.0.0"
+            },
             "engines": {
                 "node": ">=12"
             },
@@ -26763,12 +26525,12 @@
             }
         },
         "node_modules/split2": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-            "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
             "dev": true,
-            "dependencies": {
-                "readable-stream": "^3.0.0"
+            "engines": {
+                "node": ">= 10.x"
             }
         },
         "node_modules/sprintf-js": {
@@ -27564,12 +27326,15 @@
             }
         },
         "node_modules/text-extensions": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
-            "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
+            "integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
             "dev": true,
             "engines": {
-                "node": ">=0.10"
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/text-table": {
@@ -27591,15 +27356,6 @@
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
             "dev": true
-        },
-        "node_modules/through2": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-            "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-            "dev": true,
-            "dependencies": {
-                "readable-stream": "3"
-            }
         },
         "node_modules/tiny-glob": {
             "version": "0.2.9",
@@ -31696,33 +31452,33 @@
             }
         },
         "@octokit/auth-token": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
-            "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
             "dev": true
         },
         "@octokit/core": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.1.tgz",
-            "integrity": "sha512-tEDxFx8E38zF3gT7sSMDrT1tGumDgsw5yPG6BBh/X+5ClIQfMH/Yqocxz1PnHx6CHyF6pxmovUTOfZAUvQ0Lvw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.0.tgz",
+            "integrity": "sha512-YbAtMWIrbZ9FCXbLwT9wWB8TyLjq9mxpKdgB3dUNxQcIVTf9hJ70gRPwAcqGZdY6WdJPZ0I7jLaaNDCiloGN2A==",
             "dev": true,
             "requires": {
-                "@octokit/auth-token": "^3.0.0",
-                "@octokit/graphql": "^5.0.0",
-                "@octokit/request": "^6.0.0",
-                "@octokit/request-error": "^3.0.0",
-                "@octokit/types": "^9.0.0",
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.0.0",
+                "@octokit/request": "^8.0.2",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^11.0.0",
                 "before-after-hook": "^2.2.0",
                 "universal-user-agent": "^6.0.0"
             }
         },
         "@octokit/endpoint": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.5.tgz",
-            "integrity": "sha512-LG4o4HMY1Xoaec87IqQ41TQ+glvIeTKqfjkCEmt5AIwDZJwQeVZFIEYXrYY6yLwK+pAScb9Gj4q+Nz2qSw1roA==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
+            "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
             "dev": true,
             "requires": {
-                "@octokit/types": "^9.0.0",
+                "@octokit/types": "^11.0.0",
                 "is-plain-object": "^5.0.0",
                 "universal-user-agent": "^6.0.0"
             },
@@ -31736,63 +31492,62 @@
             }
         },
         "@octokit/graphql": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
-            "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.1.tgz",
+            "integrity": "sha512-T5S3oZ1JOE58gom6MIcrgwZXzTaxRnxBso58xhozxHpOqSTgDS6YNeEUvZ/kRvXgPrRz/KHnZhtb7jUMRi9E6w==",
             "dev": true,
             "requires": {
-                "@octokit/request": "^6.0.0",
-                "@octokit/types": "^9.0.0",
+                "@octokit/request": "^8.0.1",
+                "@octokit/types": "^11.0.0",
                 "universal-user-agent": "^6.0.0"
             }
         },
         "@octokit/openapi-types": {
-            "version": "17.2.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
-            "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ==",
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+            "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
             "dev": true
         },
         "@octokit/plugin-paginate-rest": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.0.0.tgz",
-            "integrity": "sha512-NNm6DlYBEyKs9OZvy2Ax9YKn7e0/G7js+/I80icBTHUf6kB/nfaZkdXOF1Z32OaB+LDH6GIYpdYC3Bm3vwX5Ow==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-8.0.0.tgz",
+            "integrity": "sha512-2xZ+baZWUg+qudVXnnvXz7qfrTmDeYPCzangBVq/1gXxii/OiS//4shJp9dnCCvj1x+JAm9ji1Egwm1BA47lPQ==",
             "dev": true,
             "requires": {
-                "@octokit/tsconfig": "^1.0.2",
-                "@octokit/types": "^9.2.3"
+                "@octokit/types": "^11.0.0"
             }
         },
         "@octokit/plugin-retry": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-5.0.2.tgz",
-            "integrity": "sha512-/Z7rWLCfjwmaVdyFuMkZoAnhfrvYgtvDrbO2d6lv7XrvJa8gFGB5tLUMngfuyMBfDCc5B9+EVu7IkQx5ebVlMg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.0.0.tgz",
+            "integrity": "sha512-a1/A4A+PB1QoAHQfLJxGHhLfSAT03bR1jJz3GgQJZvty2ozawFWs93MiBQXO7SL2YbO7CIq0Goj4qLOBj8JeMQ==",
             "dev": true,
             "requires": {
-                "@octokit/types": "^9.0.0",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^11.0.0",
                 "bottleneck": "^2.15.3"
             }
         },
         "@octokit/plugin-throttling": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.0.1.tgz",
-            "integrity": "sha512-C5h2lT+LEF4SqmbB1RbMn1PhBlHKkZoqMGS39woJr0XJ+getmOcUvrytTtS4NOn1zh/iT1ByRWYwwmFYznv83w==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-7.0.0.tgz",
+            "integrity": "sha512-KL2k/d0uANc8XqP5S64YcNFCudR3F5AaKO39XWdUtlJIjT9Ni79ekWJ6Kj5xvAw87udkOMEPcVf9xEge2+ahew==",
             "dev": true,
             "requires": {
-                "@octokit/types": "^9.0.0",
+                "@octokit/types": "^11.0.0",
                 "bottleneck": "^2.15.3"
             }
         },
         "@octokit/request": {
-            "version": "6.2.5",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.5.tgz",
-            "integrity": "sha512-z83E8UIlPNaJUsXpjD8E0V5o/5f+vJJNbNcBwVZsX3/vC650U41cOkTLjq4PKk9BYonQGOnx7N17gvLyNjgGcQ==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.1.tgz",
+            "integrity": "sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==",
             "dev": true,
             "requires": {
-                "@octokit/endpoint": "^7.0.0",
-                "@octokit/request-error": "^3.0.0",
-                "@octokit/types": "^9.0.0",
+                "@octokit/endpoint": "^9.0.0",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^11.1.0",
                 "is-plain-object": "^5.0.0",
-                "node-fetch": "^2.6.7",
                 "universal-user-agent": "^6.0.0"
             },
             "dependencies": {
@@ -31805,29 +31560,23 @@
             }
         },
         "@octokit/request-error": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
-            "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.0.tgz",
+            "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
             "dev": true,
             "requires": {
-                "@octokit/types": "^9.0.0",
+                "@octokit/types": "^11.0.0",
                 "deprecation": "^2.0.0",
                 "once": "^1.4.0"
             }
         },
-        "@octokit/tsconfig": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-            "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
-            "dev": true
-        },
         "@octokit/types": {
-            "version": "9.2.3",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
-            "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
+            "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
             "dev": true,
             "requires": {
-                "@octokit/openapi-types": "^17.2.0"
+                "@octokit/openapi-types": "^18.0.0"
             }
         },
         "@pkgjs/parseargs": {
@@ -31867,9 +31616,9 @@
             }
         },
         "@pnpm/config.env-replace": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.0.0.tgz",
-            "integrity": "sha512-ZVPVDi1E8oeXlYqkGRtX0CkzLTwE2zt62bjWaWKaAvI8NZqHzlMvGeSNDpW+JB3+aKanYb4UETJOF1/CxGPemA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+            "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
             "dev": true
         },
         "@pnpm/network.ca-file": {
@@ -31882,12 +31631,12 @@
             }
         },
         "@pnpm/npm-conf": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.1.0.tgz",
-            "integrity": "sha512-Oe6ntvgsMTE3hDIqy6sajqHF+MnzJrOF06qC2QSiUEybLL7cp6tjoKUa32gpd9+KPVl4QyMs3E3nsXrx/Vdnlw==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
+            "integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
             "dev": true,
             "requires": {
-                "@pnpm/config.env-replace": "^1.0.0",
+                "@pnpm/config.env-replace": "^1.1.0",
                 "@pnpm/network.ca-file": "^1.0.1",
                 "config-chain": "^1.1.11"
             }
@@ -32338,54 +32087,6 @@
                 "lodash": "^4.17.4"
             }
         },
-        "@semantic-release/commit-analyzer": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-10.0.1.tgz",
-            "integrity": "sha512-9ejHzTAijYs9z246sY/dKBatmOPcd0GQ7lH4MgLCkv1q4GCiDZRkjHJkaQZXZVaK7mJybS+sH3Ng6G8i3pYMGQ==",
-            "dev": true,
-            "requires": {
-                "conventional-changelog-angular": "^6.0.0",
-                "conventional-commits-filter": "^3.0.0",
-                "conventional-commits-parser": "^4.0.0",
-                "debug": "^4.0.0",
-                "import-from": "^4.0.0",
-                "lodash-es": "^4.17.21",
-                "micromatch": "^4.0.2"
-            },
-            "dependencies": {
-                "conventional-changelog-angular": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
-                    "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
-                    "dev": true,
-                    "requires": {
-                        "compare-func": "^2.0.0"
-                    }
-                },
-                "conventional-commits-filter": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
-                    "integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
-                    "dev": true,
-                    "requires": {
-                        "lodash.ismatch": "^4.4.0",
-                        "modify-values": "^1.0.1"
-                    }
-                },
-                "conventional-commits-parser": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-4.0.0.tgz",
-                    "integrity": "sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg==",
-                    "dev": true,
-                    "requires": {
-                        "is-text-path": "^1.0.1",
-                        "JSONStream": "^1.3.5",
-                        "meow": "^8.1.2",
-                        "split2": "^3.2.2"
-                    }
-                }
-            }
-        },
         "@semantic-release/error": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
@@ -32420,480 +32121,6 @@
                 "lodash": "^4.17.4",
                 "micromatch": "^4.0.0",
                 "p-reduce": "^2.0.0"
-            }
-        },
-        "@semantic-release/github": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.0.2.tgz",
-            "integrity": "sha512-FDwR9Tkz14MR/HF6srbHDuqLPUI0GmPgn4tkjfPi45/1oZedqEXC3TqSHK3+ykJmWj1sXgs94zwGI10VR5o6kg==",
-            "dev": true,
-            "requires": {
-                "@octokit/core": "^4.2.1",
-                "@octokit/plugin-paginate-rest": "^7.0.0",
-                "@octokit/plugin-retry": "^5.0.0",
-                "@octokit/plugin-throttling": "^6.0.0",
-                "@semantic-release/error": "^3.0.0",
-                "aggregate-error": "^4.0.1",
-                "debug": "^4.3.4",
-                "dir-glob": "^3.0.1",
-                "globby": "^13.1.4",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.0",
-                "issue-parser": "^6.0.0",
-                "lodash-es": "^4.17.21",
-                "mime": "^3.0.0",
-                "p-filter": "^3.0.0",
-                "url-join": "^5.0.0"
-            },
-            "dependencies": {
-                "agent-base": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-                    "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-                    "dev": true,
-                    "requires": {
-                        "debug": "^4.3.4"
-                    }
-                },
-                "aggregate-error": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
-                    "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-                    "dev": true,
-                    "requires": {
-                        "clean-stack": "^4.0.0",
-                        "indent-string": "^5.0.0"
-                    }
-                },
-                "clean-stack": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-                    "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-                    "dev": true,
-                    "requires": {
-                        "escape-string-regexp": "5.0.0"
-                    }
-                },
-                "escape-string-regexp": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-                    "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-                    "dev": true
-                },
-                "globby": {
-                    "version": "13.2.2",
-                    "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-                    "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-                    "dev": true,
-                    "requires": {
-                        "dir-glob": "^3.0.1",
-                        "fast-glob": "^3.3.0",
-                        "ignore": "^5.2.4",
-                        "merge2": "^1.4.1",
-                        "slash": "^4.0.0"
-                    }
-                },
-                "http-proxy-agent": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
-                    "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
-                    "dev": true,
-                    "requires": {
-                        "agent-base": "^7.1.0",
-                        "debug": "^4.3.4"
-                    }
-                },
-                "https-proxy-agent": {
-                    "version": "7.0.2",
-                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
-                    "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
-                    "dev": true,
-                    "requires": {
-                        "agent-base": "^7.0.2",
-                        "debug": "4"
-                    }
-                },
-                "indent-string": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-                    "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-                    "dev": true
-                },
-                "slash": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-                    "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-                    "dev": true
-                }
-            }
-        },
-        "@semantic-release/npm": {
-            "version": "10.0.2",
-            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-10.0.2.tgz",
-            "integrity": "sha512-Mo0XoBza4pUapxiBhLLYXeSZ9tkuHDUd/WvMbpilwuPRfJDnQXMqx5tBVon8d2mBk8JXmXpqB+ExhlWJmVT40A==",
-            "dev": true,
-            "requires": {
-                "@semantic-release/error": "^3.0.0",
-                "aggregate-error": "^4.0.1",
-                "execa": "^7.0.0",
-                "fs-extra": "^11.0.0",
-                "lodash-es": "^4.17.21",
-                "nerf-dart": "^1.0.0",
-                "normalize-url": "^8.0.0",
-                "npm": "^9.5.0",
-                "rc": "^1.2.8",
-                "read-pkg": "^7.0.0",
-                "registry-auth-token": "^5.0.0",
-                "semver": "^7.1.2",
-                "tempy": "^3.0.0"
-            },
-            "dependencies": {
-                "aggregate-error": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
-                    "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-                    "dev": true,
-                    "requires": {
-                        "clean-stack": "^4.0.0",
-                        "indent-string": "^5.0.0"
-                    }
-                },
-                "clean-stack": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-                    "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-                    "dev": true,
-                    "requires": {
-                        "escape-string-regexp": "5.0.0"
-                    }
-                },
-                "crypto-random-string": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
-                    "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
-                    "dev": true,
-                    "requires": {
-                        "type-fest": "^1.0.1"
-                    },
-                    "dependencies": {
-                        "type-fest": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-                            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-                            "dev": true
-                        }
-                    }
-                },
-                "escape-string-regexp": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-                    "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-                    "dev": true
-                },
-                "execa": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
-                    "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
-                    "dev": true,
-                    "requires": {
-                        "cross-spawn": "^7.0.3",
-                        "get-stream": "^6.0.1",
-                        "human-signals": "^4.3.0",
-                        "is-stream": "^3.0.0",
-                        "merge-stream": "^2.0.0",
-                        "npm-run-path": "^5.1.0",
-                        "onetime": "^6.0.0",
-                        "signal-exit": "^3.0.7",
-                        "strip-final-newline": "^3.0.0"
-                    }
-                },
-                "hosted-git-info": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-                    "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "human-signals": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-                    "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
-                    "dev": true
-                },
-                "indent-string": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-                    "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-                    "dev": true
-                },
-                "is-stream": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-                    "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-                    "dev": true
-                },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
-                "mimic-fn": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-                    "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-                    "dev": true
-                },
-                "normalize-package-data": {
-                    "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-                    "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-                    "dev": true,
-                    "requires": {
-                        "hosted-git-info": "^4.0.1",
-                        "is-core-module": "^2.5.0",
-                        "semver": "^7.3.4",
-                        "validate-npm-package-license": "^3.0.1"
-                    }
-                },
-                "npm-run-path": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-                    "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
-                    "dev": true,
-                    "requires": {
-                        "path-key": "^4.0.0"
-                    }
-                },
-                "onetime": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-                    "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-                    "dev": true,
-                    "requires": {
-                        "mimic-fn": "^4.0.0"
-                    }
-                },
-                "path-key": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-                    "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-                    "dev": true
-                },
-                "read-pkg": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
-                    "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
-                    "dev": true,
-                    "requires": {
-                        "@types/normalize-package-data": "^2.4.1",
-                        "normalize-package-data": "^3.0.2",
-                        "parse-json": "^5.2.0",
-                        "type-fest": "^2.0.0"
-                    }
-                },
-                "semver": {
-                    "version": "7.5.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "strip-final-newline": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-                    "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-                    "dev": true
-                },
-                "temp-dir": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
-                    "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
-                    "dev": true
-                },
-                "tempy": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
-                    "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
-                    "dev": true,
-                    "requires": {
-                        "is-stream": "^3.0.0",
-                        "temp-dir": "^3.0.0",
-                        "type-fest": "^2.12.2",
-                        "unique-string": "^3.0.0"
-                    }
-                },
-                "type-fest": {
-                    "version": "2.19.0",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-                    "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-                    "dev": true
-                },
-                "unique-string": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
-                    "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
-                    "dev": true,
-                    "requires": {
-                        "crypto-random-string": "^4.0.0"
-                    }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true
-                }
-            }
-        },
-        "@semantic-release/release-notes-generator": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-11.0.1.tgz",
-            "integrity": "sha512-4deWsiY4Rg80oc9Ms11N20BIDgYkPMys4scNYQpi2Njdrtw5Z55nXKNsUN3kn6Sy/nI9dqqbp5L63TL4luI5Bw==",
-            "dev": true,
-            "requires": {
-                "conventional-changelog-angular": "^5.0.0",
-                "conventional-changelog-writer": "^5.0.0",
-                "conventional-commits-filter": "^2.0.0",
-                "conventional-commits-parser": "^3.2.3",
-                "debug": "^4.0.0",
-                "get-stream": "^6.0.0",
-                "import-from": "^4.0.0",
-                "into-stream": "^7.0.0",
-                "lodash-es": "^4.17.21",
-                "read-pkg-up": "^9.0.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-                    "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^7.1.0",
-                        "path-exists": "^5.0.0"
-                    }
-                },
-                "hosted-git-info": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-                    "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-                    "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^6.0.0"
-                    }
-                },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
-                "normalize-package-data": {
-                    "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-                    "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-                    "dev": true,
-                    "requires": {
-                        "hosted-git-info": "^4.0.1",
-                        "is-core-module": "^2.5.0",
-                        "semver": "^7.3.4",
-                        "validate-npm-package-license": "^3.0.1"
-                    }
-                },
-                "p-limit": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-                    "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-                    "dev": true,
-                    "requires": {
-                        "yocto-queue": "^1.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-                    "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^4.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-                    "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-                    "dev": true
-                },
-                "read-pkg": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
-                    "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
-                    "dev": true,
-                    "requires": {
-                        "@types/normalize-package-data": "^2.4.1",
-                        "normalize-package-data": "^3.0.2",
-                        "parse-json": "^5.2.0",
-                        "type-fest": "^2.0.0"
-                    }
-                },
-                "read-pkg-up": {
-                    "version": "9.1.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
-                    "integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "^6.3.0",
-                        "read-pkg": "^7.1.0",
-                        "type-fest": "^2.5.0"
-                    }
-                },
-                "semver": {
-                    "version": "7.5.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "type-fest": {
-                    "version": "2.19.0",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-                    "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-                    "dev": true
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true
-                },
-                "yocto-queue": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-                    "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-                    "dev": true
-                }
             }
         },
         "@sinclair/typebox": {
@@ -37049,13 +36276,12 @@
             "dev": true
         },
         "conventional-changelog-angular": {
-            "version": "5.0.13",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
-            "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
+            "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
             "dev": true,
             "requires": {
-                "compare-func": "^2.0.0",
-                "q": "^1.5.1"
+                "compare-func": "^2.0.0"
             }
         },
         "conventional-changelog-conventionalcommits": {
@@ -37068,44 +36294,112 @@
             }
         },
         "conventional-changelog-writer": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
-            "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-6.0.1.tgz",
+            "integrity": "sha512-359t9aHorPw+U+nHzUXHS5ZnPBOizRxfQsWT5ZDHBfvfxQOAik+yfuhKXG66CN5LEWPpMNnIMHUTCKeYNprvHQ==",
             "dev": true,
             "requires": {
-                "conventional-commits-filter": "^2.0.7",
-                "dateformat": "^3.0.0",
+                "conventional-commits-filter": "^3.0.0",
+                "dateformat": "^3.0.3",
                 "handlebars": "^4.7.7",
                 "json-stringify-safe": "^5.0.1",
-                "lodash": "^4.17.15",
-                "meow": "^8.0.0",
-                "semver": "^6.0.0",
-                "split": "^1.0.0",
-                "through2": "^4.0.0"
+                "meow": "^8.1.2",
+                "semver": "^7.0.0",
+                "split": "^1.0.1"
+            },
+            "dependencies": {
+                "hosted-git-info": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+                    "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "meow": {
+                    "version": "8.1.2",
+                    "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+                    "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+                    "dev": true,
+                    "requires": {
+                        "@types/minimist": "^1.2.0",
+                        "camelcase-keys": "^6.2.2",
+                        "decamelize-keys": "^1.1.0",
+                        "hard-rejection": "^2.1.0",
+                        "minimist-options": "4.1.0",
+                        "normalize-package-data": "^3.0.0",
+                        "read-pkg-up": "^7.0.1",
+                        "redent": "^3.0.0",
+                        "trim-newlines": "^3.0.0",
+                        "type-fest": "^0.18.0",
+                        "yargs-parser": "^20.2.3"
+                    }
+                },
+                "normalize-package-data": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+                    "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+                    "dev": true,
+                    "requires": {
+                        "hosted-git-info": "^4.0.1",
+                        "is-core-module": "^2.5.0",
+                        "semver": "^7.3.4",
+                        "validate-npm-package-license": "^3.0.1"
+                    }
+                },
+                "semver": {
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.18.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+                    "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "dev": true
+                }
             }
         },
         "conventional-commits-filter": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
-            "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
+            "integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
             "dev": true,
             "requires": {
                 "lodash.ismatch": "^4.4.0",
-                "modify-values": "^1.0.0"
+                "modify-values": "^1.0.1"
             }
         },
         "conventional-commits-parser": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
-            "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
+            "integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
             "dev": true,
             "requires": {
-                "is-text-path": "^1.0.1",
-                "JSONStream": "^1.0.4",
-                "lodash": "^4.17.15",
-                "meow": "^8.0.0",
-                "split2": "^3.0.0",
-                "through2": "^4.0.0"
+                "is-text-path": "^2.0.0",
+                "JSONStream": "^1.3.5",
+                "meow": "^12.0.1",
+                "split2": "^4.0.0"
             }
         },
         "convert-source-map": {
@@ -40567,12 +39861,12 @@
             }
         },
         "is-text-path": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-            "integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+            "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
             "dev": true,
             "requires": {
-                "text-extensions": "^1.0.0"
+                "text-extensions": "^2.0.0"
             }
         },
         "is-typed-array": {
@@ -42302,76 +41596,10 @@
             "dev": true
         },
         "meow": {
-            "version": "8.1.2",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
-            "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
-            "dev": true,
-            "requires": {
-                "@types/minimist": "^1.2.0",
-                "camelcase-keys": "^6.2.2",
-                "decamelize-keys": "^1.1.0",
-                "hard-rejection": "^2.1.0",
-                "minimist-options": "4.1.0",
-                "normalize-package-data": "^3.0.0",
-                "read-pkg-up": "^7.0.1",
-                "redent": "^3.0.0",
-                "trim-newlines": "^3.0.0",
-                "type-fest": "^0.18.0",
-                "yargs-parser": "^20.2.3"
-            },
-            "dependencies": {
-                "hosted-git-info": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-                    "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
-                "normalize-package-data": {
-                    "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-                    "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-                    "dev": true,
-                    "requires": {
-                        "hosted-git-info": "^4.0.1",
-                        "is-core-module": "^2.5.0",
-                        "semver": "^7.3.4",
-                        "validate-npm-package-license": "^3.0.1"
-                    }
-                },
-                "semver": {
-                    "version": "7.5.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "type-fest": {
-                    "version": "0.18.1",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-                    "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-                    "dev": true
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true
-                }
-            }
+            "version": "12.1.1",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+            "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+            "dev": true
         },
         "merge-descriptors": {
             "version": "1.0.1",
@@ -43033,77 +42261,79 @@
             "dev": true
         },
         "npm": {
-            "version": "9.6.2",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-9.6.2.tgz",
-            "integrity": "sha512-TnXoXhlFkH/9wI4+aXSq0aPLwKG7Ge17t1ME4/rQt+0DZWQCRk9PwhBuX/shqdUiHeKicSLSkzWx+QZgTRE+/A==",
+            "version": "9.8.1",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.1.tgz",
+            "integrity": "sha512-AfDvThQzsIXhYgk9zhbk5R+lh811lKkLAeQMMhSypf1BM7zUafeIIBzMzespeuVEJ0+LvY36oRQYf7IKLzU3rw==",
             "dev": true,
             "requires": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^6.2.5",
-                "@npmcli/config": "^6.1.4",
-                "@npmcli/map-workspaces": "^3.0.2",
-                "@npmcli/package-json": "^3.0.0",
-                "@npmcli/run-script": "^6.0.0",
+                "@npmcli/arborist": "^6.3.0",
+                "@npmcli/config": "^6.2.1",
+                "@npmcli/fs": "^3.1.0",
+                "@npmcli/map-workspaces": "^3.0.4",
+                "@npmcli/package-json": "^4.0.1",
+                "@npmcli/promise-spawn": "^6.0.2",
+                "@npmcli/run-script": "^6.0.2",
                 "abbrev": "^2.0.0",
                 "archy": "~1.0.0",
-                "cacache": "^17.0.4",
-                "chalk": "^4.1.2",
+                "cacache": "^17.1.3",
+                "chalk": "^5.3.0",
                 "ci-info": "^3.8.0",
                 "cli-columns": "^4.0.0",
                 "cli-table3": "^0.6.3",
                 "columnify": "^1.6.0",
                 "fastest-levenshtein": "^1.0.16",
-                "fs-minipass": "^3.0.1",
-                "glob": "^8.1.0",
-                "graceful-fs": "^4.2.10",
+                "fs-minipass": "^3.0.2",
+                "glob": "^10.2.7",
+                "graceful-fs": "^4.2.11",
                 "hosted-git-info": "^6.1.1",
-                "ini": "^3.0.1",
+                "ini": "^4.1.1",
                 "init-package-json": "^5.0.0",
                 "is-cidr": "^4.0.2",
                 "json-parse-even-better-errors": "^3.0.0",
                 "libnpmaccess": "^7.0.2",
-                "libnpmdiff": "^5.0.13",
-                "libnpmexec": "^5.0.13",
-                "libnpmfund": "^4.0.13",
+                "libnpmdiff": "^5.0.19",
+                "libnpmexec": "^6.0.3",
+                "libnpmfund": "^4.0.19",
                 "libnpmhook": "^9.0.3",
-                "libnpmorg": "^5.0.3",
-                "libnpmpack": "^5.0.13",
-                "libnpmpublish": "^7.1.2",
+                "libnpmorg": "^5.0.4",
+                "libnpmpack": "^5.0.19",
+                "libnpmpublish": "^7.5.0",
                 "libnpmsearch": "^6.0.2",
                 "libnpmteam": "^5.0.3",
                 "libnpmversion": "^4.0.2",
-                "make-fetch-happen": "^11.0.3",
-                "minimatch": "^6.2.0",
-                "minipass": "^4.2.4",
+                "make-fetch-happen": "^11.1.1",
+                "minimatch": "^9.0.3",
+                "minipass": "^5.0.0",
                 "minipass-pipeline": "^1.2.4",
                 "ms": "^2.1.2",
-                "node-gyp": "^9.3.1",
-                "nopt": "^7.0.0",
-                "npm-audit-report": "^4.0.0",
-                "npm-install-checks": "^6.0.0",
+                "node-gyp": "^9.4.0",
+                "nopt": "^7.2.0",
+                "npm-audit-report": "^5.0.0",
+                "npm-install-checks": "^6.1.1",
                 "npm-package-arg": "^10.1.0",
                 "npm-pick-manifest": "^8.0.1",
                 "npm-profile": "^7.0.1",
-                "npm-registry-fetch": "^14.0.3",
+                "npm-registry-fetch": "^14.0.5",
                 "npm-user-validate": "^2.0.0",
                 "npmlog": "^7.0.1",
                 "p-map": "^4.0.0",
-                "pacote": "^15.1.1",
-                "parse-conflict-json": "^3.0.0",
+                "pacote": "^15.2.0",
+                "parse-conflict-json": "^3.0.1",
                 "proc-log": "^3.0.0",
                 "qrcode-terminal": "^0.12.0",
-                "read": "^2.0.0",
-                "read-package-json": "^6.0.0",
-                "read-package-json-fast": "^3.0.2",
-                "semver": "^7.3.8",
-                "ssri": "^10.0.1",
-                "tar": "^6.1.13",
+                "read": "^2.1.0",
+                "semver": "^7.5.4",
+                "sigstore": "^1.7.0",
+                "ssri": "^10.0.4",
+                "supports-color": "^9.4.0",
+                "tar": "^6.1.15",
                 "text-table": "~0.2.0",
                 "tiny-relative-date": "^1.3.0",
                 "treeverse": "^3.0.0",
                 "validate-npm-package-name": "^5.0.0",
-                "which": "^3.0.0",
-                "write-file-atomic": "^5.0.0"
+                "which": "^3.0.1",
+                "write-file-atomic": "^5.0.1"
             },
             "dependencies": {
                 "@colors/colors": {
@@ -43112,10 +42342,48 @@
                     "dev": true,
                     "optional": true
                 },
-                "@gar/promisify": {
-                    "version": "1.1.3",
+                "@isaacs/cliui": {
+                    "version": "8.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^5.1.2",
+                        "string-width-cjs": "npm:string-width@^4.2.0",
+                        "strip-ansi": "^7.0.1",
+                        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                        "wrap-ansi": "^8.1.0",
+                        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "6.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "emoji-regex": {
+                            "version": "9.2.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "string-width": {
+                            "version": "5.1.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "eastasianwidth": "^0.2.0",
+                                "emoji-regex": "^9.2.2",
+                                "strip-ansi": "^7.0.1"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "7.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^6.0.1"
+                            }
+                        }
+                    }
                 },
                 "@isaacs/string-locale-compare": {
                     "version": "1.1.0",
@@ -43123,7 +42391,7 @@
                     "dev": true
                 },
                 "@npmcli/arborist": {
-                    "version": "6.2.5",
+                    "version": "6.3.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -43134,7 +42402,7 @@
                         "@npmcli/metavuln-calculator": "^5.0.0",
                         "@npmcli/name-from-folder": "^2.0.0",
                         "@npmcli/node-gyp": "^3.0.0",
-                        "@npmcli/package-json": "^3.0.0",
+                        "@npmcli/package-json": "^4.0.0",
                         "@npmcli/query": "^3.0.0",
                         "@npmcli/run-script": "^6.0.0",
                         "bin-links": "^4.0.1",
@@ -43143,7 +42411,7 @@
                         "hosted-git-info": "^6.1.1",
                         "json-parse-even-better-errors": "^3.0.0",
                         "json-stringify-nice": "^1.1.4",
-                        "minimatch": "^6.1.6",
+                        "minimatch": "^9.0.0",
                         "nopt": "^7.0.0",
                         "npm-install-checks": "^6.0.0",
                         "npm-package-arg": "^10.1.0",
@@ -43154,26 +42422,27 @@
                         "parse-conflict-json": "^3.0.0",
                         "proc-log": "^3.0.0",
                         "promise-all-reject-late": "^1.0.0",
-                        "promise-call-limit": "^1.0.1",
+                        "promise-call-limit": "^1.0.2",
                         "read-package-json-fast": "^3.0.2",
                         "semver": "^7.3.7",
                         "ssri": "^10.0.1",
                         "treeverse": "^3.0.0",
-                        "walk-up-path": "^1.0.0"
+                        "walk-up-path": "^3.0.1"
                     }
                 },
                 "@npmcli/config": {
-                    "version": "6.1.4",
+                    "version": "6.2.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "@npmcli/map-workspaces": "^3.0.2",
-                        "ini": "^3.0.0",
+                        "ci-info": "^3.8.0",
+                        "ini": "^4.1.0",
                         "nopt": "^7.0.0",
                         "proc-log": "^3.0.0",
                         "read-package-json-fast": "^3.0.2",
                         "semver": "^7.3.5",
-                        "walk-up-path": "^1.0.0"
+                        "walk-up-path": "^3.0.1"
                     }
                 },
                 "@npmcli/disparity-colors": {
@@ -43193,13 +42462,12 @@
                     }
                 },
                 "@npmcli/git": {
-                    "version": "4.0.3",
+                    "version": "4.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "@npmcli/promise-spawn": "^6.0.0",
                         "lru-cache": "^7.4.4",
-                        "mkdirp": "^1.0.4",
                         "npm-pick-manifest": "^8.0.0",
                         "proc-log": "^3.0.0",
                         "promise-inflight": "^1.0.1",
@@ -43218,18 +42486,18 @@
                     }
                 },
                 "@npmcli/map-workspaces": {
-                    "version": "3.0.2",
+                    "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "@npmcli/name-from-folder": "^2.0.0",
-                        "glob": "^8.0.1",
-                        "minimatch": "^6.1.6",
+                        "glob": "^10.2.2",
+                        "minimatch": "^9.0.0",
                         "read-package-json-fast": "^3.0.0"
                     }
                 },
                 "@npmcli/metavuln-calculator": {
-                    "version": "5.0.0",
+                    "version": "5.0.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -43237,15 +42505,6 @@
                         "json-parse-even-better-errors": "^3.0.0",
                         "pacote": "^15.0.0",
                         "semver": "^7.3.5"
-                    }
-                },
-                "@npmcli/move-file": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "mkdirp": "^1.0.4",
-                        "rimraf": "^3.0.2"
                     }
                 },
                 "@npmcli/name-from-folder": {
@@ -43259,11 +42518,17 @@
                     "dev": true
                 },
                 "@npmcli/package-json": {
-                    "version": "3.0.0",
+                    "version": "4.0.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "json-parse-even-better-errors": "^3.0.0"
+                        "@npmcli/git": "^4.1.0",
+                        "glob": "^10.2.2",
+                        "hosted-git-info": "^6.1.1",
+                        "json-parse-even-better-errors": "^3.0.0",
+                        "normalize-package-data": "^5.0.0",
+                        "proc-log": "^3.0.0",
+                        "semver": "^7.5.3"
                     }
                 },
                 "@npmcli/promise-spawn": {
@@ -43283,7 +42548,7 @@
                     }
                 },
                 "@npmcli/run-script": {
-                    "version": "6.0.0",
+                    "version": "6.0.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -43294,22 +42559,43 @@
                         "which": "^3.0.0"
                     }
                 },
+                "@pkgjs/parseargs": {
+                    "version": "0.11.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
                 "@sigstore/protobuf-specs": {
                     "version": "0.1.0",
                     "bundled": true,
                     "dev": true
+                },
+                "@sigstore/tuf": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@sigstore/protobuf-specs": "^0.1.0",
+                        "tuf-js": "^1.1.7"
+                    }
                 },
                 "@tootallnate/once": {
                     "version": "2.0.0",
                     "bundled": true,
                     "dev": true
                 },
-                "@tufjs/models": {
+                "@tufjs/canonical-json": {
                     "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "@tufjs/models": {
+                    "version": "1.0.4",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "minimatch": "^6.1.0"
+                        "@tufjs/canonical-json": "1.0.0",
+                        "minimatch": "^9.0.0"
                     }
                 },
                 "abbrev": {
@@ -43395,7 +42681,7 @@
                     "dev": true
                 },
                 "bin-links": {
-                    "version": "4.0.1",
+                    "version": "4.0.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -43436,33 +42722,28 @@
                     }
                 },
                 "cacache": {
-                    "version": "17.0.4",
+                    "version": "17.1.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "@npmcli/fs": "^3.1.0",
                         "fs-minipass": "^3.0.0",
-                        "glob": "^8.0.1",
+                        "glob": "^10.2.2",
                         "lru-cache": "^7.7.1",
-                        "minipass": "^4.0.0",
+                        "minipass": "^5.0.0",
                         "minipass-collect": "^1.0.2",
                         "minipass-flush": "^1.0.5",
                         "minipass-pipeline": "^1.2.4",
                         "p-map": "^4.0.0",
-                        "promise-inflight": "^1.0.1",
                         "ssri": "^10.0.0",
                         "tar": "^6.1.11",
                         "unique-filename": "^3.0.0"
                     }
                 },
                 "chalk": {
-                    "version": "4.1.2",
+                    "version": "5.3.0",
                     "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
+                    "dev": true
                 },
                 "chownr": {
                     "version": "2.0.0",
@@ -43557,6 +42838,26 @@
                     "bundled": true,
                     "dev": true
                 },
+                "cross-spawn": {
+                    "version": "7.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^2.0.0",
+                        "which": "^2.0.1"
+                    },
+                    "dependencies": {
+                        "which": {
+                            "version": "2.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "isexe": "^2.0.0"
+                            }
+                        }
+                    }
+                },
                 "cssesc": {
                     "version": "3.0.0",
                     "bundled": true,
@@ -43600,6 +42901,11 @@
                     "bundled": true,
                     "dev": true
                 },
+                "eastasianwidth": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
                 "emoji-regex": {
                     "version": "8.0.0",
                     "bundled": true,
@@ -43634,17 +42940,31 @@
                     "bundled": true,
                     "dev": true
                 },
+                "exponential-backoff": {
+                    "version": "3.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
                 "fastest-levenshtein": {
                     "version": "1.0.16",
                     "bundled": true,
                     "dev": true
                 },
-                "fs-minipass": {
-                    "version": "3.0.1",
+                "foreground-child": {
+                    "version": "3.1.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "minipass": "^4.0.0"
+                        "cross-spawn": "^7.0.0",
+                        "signal-exit": "^4.0.1"
+                    }
+                },
+                "fs-minipass": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^5.0.0"
                     }
                 },
                 "fs.realpath": {
@@ -43658,7 +42978,7 @@
                     "dev": true
                 },
                 "gauge": {
-                    "version": "5.0.0",
+                    "version": "5.0.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -43666,36 +42986,26 @@
                         "color-support": "^1.1.3",
                         "console-control-strings": "^1.1.0",
                         "has-unicode": "^2.0.1",
-                        "signal-exit": "^3.0.7",
+                        "signal-exit": "^4.0.1",
                         "string-width": "^4.2.3",
                         "strip-ansi": "^6.0.1",
                         "wide-align": "^1.1.5"
                     }
                 },
                 "glob": {
-                    "version": "8.1.0",
+                    "version": "10.2.7",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^5.0.1",
-                        "once": "^1.3.0"
-                    },
-                    "dependencies": {
-                        "minimatch": {
-                            "version": "5.1.6",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "brace-expansion": "^2.0.1"
-                            }
-                        }
+                        "foreground-child": "^3.1.0",
+                        "jackspeak": "^2.0.3",
+                        "minimatch": "^9.0.1",
+                        "minipass": "^5.0.0 || ^6.0.2",
+                        "path-scurry": "^1.7.0"
                     }
                 },
                 "graceful-fs": {
-                    "version": "4.2.10",
+                    "version": "4.2.11",
                     "bundled": true,
                     "dev": true
                 },
@@ -43706,11 +43016,6 @@
                     "requires": {
                         "function-bind": "^1.1.1"
                     }
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "bundled": true,
-                    "dev": true
                 },
                 "has-unicode": {
                     "version": "2.0.1",
@@ -43772,11 +43077,11 @@
                     "dev": true
                 },
                 "ignore-walk": {
-                    "version": "6.0.1",
+                    "version": "6.0.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "minimatch": "^6.1.6"
+                        "minimatch": "^9.0.0"
                     }
                 },
                 "imurmurhash": {
@@ -43786,11 +43091,6 @@
                 },
                 "indent-string": {
                     "version": "4.0.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "infer-owner": {
-                    "version": "1.0.4",
                     "bundled": true,
                     "dev": true
                 },
@@ -43809,7 +43109,7 @@
                     "dev": true
                 },
                 "ini": {
-                    "version": "3.0.1",
+                    "version": "4.1.1",
                     "bundled": true,
                     "dev": true
                 },
@@ -43846,7 +43146,7 @@
                     }
                 },
                 "is-core-module": {
-                    "version": "2.11.0",
+                    "version": "2.12.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -43868,6 +43168,15 @@
                     "bundled": true,
                     "dev": true
                 },
+                "jackspeak": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@isaacs/cliui": "^8.0.2",
+                        "@pkgjs/parseargs": "^0.11.0"
+                    }
+                },
                 "json-parse-even-better-errors": {
                     "version": "3.0.0",
                     "bundled": true,
@@ -43884,7 +43193,7 @@
                     "dev": true
                 },
                 "just-diff": {
-                    "version": "5.2.0",
+                    "version": "6.0.2",
                     "bundled": true,
                     "dev": true
                 },
@@ -43903,29 +43212,28 @@
                     }
                 },
                 "libnpmdiff": {
-                    "version": "5.0.13",
+                    "version": "5.0.19",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "@npmcli/arborist": "^6.2.5",
+                        "@npmcli/arborist": "^6.3.0",
                         "@npmcli/disparity-colors": "^3.0.0",
                         "@npmcli/installed-package-contents": "^2.0.2",
                         "binary-extensions": "^2.2.0",
                         "diff": "^5.1.0",
-                        "minimatch": "^6.1.6",
+                        "minimatch": "^9.0.0",
                         "npm-package-arg": "^10.1.0",
                         "pacote": "^15.0.8",
                         "tar": "^6.1.13"
                     }
                 },
                 "libnpmexec": {
-                    "version": "5.0.13",
+                    "version": "6.0.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "@npmcli/arborist": "^6.2.5",
+                        "@npmcli/arborist": "^6.3.0",
                         "@npmcli/run-script": "^6.0.0",
-                        "chalk": "^4.1.0",
                         "ci-info": "^3.7.1",
                         "npm-package-arg": "^10.1.0",
                         "npmlog": "^7.0.1",
@@ -43934,15 +43242,15 @@
                         "read": "^2.0.0",
                         "read-package-json-fast": "^3.0.2",
                         "semver": "^7.3.7",
-                        "walk-up-path": "^1.0.0"
+                        "walk-up-path": "^3.0.1"
                     }
                 },
                 "libnpmfund": {
-                    "version": "4.0.13",
+                    "version": "4.0.19",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "@npmcli/arborist": "^6.2.5"
+                        "@npmcli/arborist": "^6.3.0"
                     }
                 },
                 "libnpmhook": {
@@ -43955,7 +43263,7 @@
                     }
                 },
                 "libnpmorg": {
-                    "version": "5.0.3",
+                    "version": "5.0.4",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -43964,18 +43272,18 @@
                     }
                 },
                 "libnpmpack": {
-                    "version": "5.0.13",
+                    "version": "5.0.19",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "@npmcli/arborist": "^6.2.5",
+                        "@npmcli/arborist": "^6.3.0",
                         "@npmcli/run-script": "^6.0.0",
                         "npm-package-arg": "^10.1.0",
                         "pacote": "^15.0.8"
                     }
                 },
                 "libnpmpublish": {
-                    "version": "7.1.2",
+                    "version": "7.5.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -43985,7 +43293,7 @@
                         "npm-registry-fetch": "^14.0.3",
                         "proc-log": "^3.0.0",
                         "semver": "^7.3.7",
-                        "sigstore": "^1.0.0",
+                        "sigstore": "^1.4.0",
                         "ssri": "^10.0.1"
                     }
                 },
@@ -44024,7 +43332,7 @@
                     "dev": true
                 },
                 "make-fetch-happen": {
-                    "version": "11.0.3",
+                    "version": "11.1.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -44035,7 +43343,7 @@
                         "https-proxy-agent": "^5.0.0",
                         "is-lambda": "^1.0.1",
                         "lru-cache": "^7.7.1",
-                        "minipass": "^4.0.0",
+                        "minipass": "^5.0.0",
                         "minipass-fetch": "^3.0.0",
                         "minipass-flush": "^1.0.5",
                         "minipass-pipeline": "^1.2.4",
@@ -44046,7 +43354,7 @@
                     }
                 },
                 "minimatch": {
-                    "version": "6.2.0",
+                    "version": "9.0.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -44054,7 +43362,7 @@
                     }
                 },
                 "minipass": {
-                    "version": "4.2.4",
+                    "version": "5.0.0",
                     "bundled": true,
                     "dev": true
                 },
@@ -44077,12 +43385,12 @@
                     }
                 },
                 "minipass-fetch": {
-                    "version": "3.0.1",
+                    "version": "3.0.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "encoding": "^0.1.13",
-                        "minipass": "^4.0.0",
+                        "minipass": "^5.0.0",
                         "minipass-sized": "^1.0.3",
                         "minizlib": "^2.1.2"
                     }
@@ -44200,14 +43508,15 @@
                     "dev": true
                 },
                 "node-gyp": {
-                    "version": "9.3.1",
+                    "version": "9.4.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "env-paths": "^2.2.0",
+                        "exponential-backoff": "^3.1.1",
                         "glob": "^7.1.4",
                         "graceful-fs": "^4.2.6",
-                        "make-fetch-happen": "^10.0.3",
+                        "make-fetch-happen": "^11.0.3",
                         "nopt": "^6.0.0",
                         "npmlog": "^6.0.0",
                         "rimraf": "^3.0.2",
@@ -44216,15 +43525,6 @@
                         "which": "^2.0.2"
                     },
                     "dependencies": {
-                        "@npmcli/fs": {
-                            "version": "2.1.2",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "@gar/promisify": "^1.1.3",
-                                "semver": "^7.3.5"
-                            }
-                        },
                         "abbrev": {
                             "version": "1.1.1",
                             "bundled": true,
@@ -44246,69 +43546,6 @@
                             "requires": {
                                 "balanced-match": "^1.0.0",
                                 "concat-map": "0.0.1"
-                            }
-                        },
-                        "cacache": {
-                            "version": "16.1.3",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "@npmcli/fs": "^2.1.0",
-                                "@npmcli/move-file": "^2.0.0",
-                                "chownr": "^2.0.0",
-                                "fs-minipass": "^2.1.0",
-                                "glob": "^8.0.1",
-                                "infer-owner": "^1.0.4",
-                                "lru-cache": "^7.7.1",
-                                "minipass": "^3.1.6",
-                                "minipass-collect": "^1.0.2",
-                                "minipass-flush": "^1.0.5",
-                                "minipass-pipeline": "^1.2.4",
-                                "mkdirp": "^1.0.4",
-                                "p-map": "^4.0.0",
-                                "promise-inflight": "^1.0.1",
-                                "rimraf": "^3.0.2",
-                                "ssri": "^9.0.0",
-                                "tar": "^6.1.11",
-                                "unique-filename": "^2.0.0"
-                            },
-                            "dependencies": {
-                                "brace-expansion": {
-                                    "version": "2.0.1",
-                                    "bundled": true,
-                                    "dev": true,
-                                    "requires": {
-                                        "balanced-match": "^1.0.0"
-                                    }
-                                },
-                                "glob": {
-                                    "version": "8.1.0",
-                                    "bundled": true,
-                                    "dev": true,
-                                    "requires": {
-                                        "fs.realpath": "^1.0.0",
-                                        "inflight": "^1.0.4",
-                                        "inherits": "2",
-                                        "minimatch": "^5.0.1",
-                                        "once": "^1.3.0"
-                                    }
-                                },
-                                "minimatch": {
-                                    "version": "5.1.6",
-                                    "bundled": true,
-                                    "dev": true,
-                                    "requires": {
-                                        "brace-expansion": "^2.0.1"
-                                    }
-                                }
-                            }
-                        },
-                        "fs-minipass": {
-                            "version": "2.1.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "minipass": "^3.0.0"
                             }
                         },
                         "gauge": {
@@ -44339,54 +43576,12 @@
                                 "path-is-absolute": "^1.0.0"
                             }
                         },
-                        "make-fetch-happen": {
-                            "version": "10.2.1",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "agentkeepalive": "^4.2.1",
-                                "cacache": "^16.1.0",
-                                "http-cache-semantics": "^4.1.0",
-                                "http-proxy-agent": "^5.0.0",
-                                "https-proxy-agent": "^5.0.0",
-                                "is-lambda": "^1.0.1",
-                                "lru-cache": "^7.7.1",
-                                "minipass": "^3.1.6",
-                                "minipass-collect": "^1.0.2",
-                                "minipass-fetch": "^2.0.3",
-                                "minipass-flush": "^1.0.5",
-                                "minipass-pipeline": "^1.2.4",
-                                "negotiator": "^0.6.3",
-                                "promise-retry": "^2.0.1",
-                                "socks-proxy-agent": "^7.0.0",
-                                "ssri": "^9.0.0"
-                            }
-                        },
                         "minimatch": {
                             "version": "3.1.2",
                             "bundled": true,
                             "dev": true,
                             "requires": {
                                 "brace-expansion": "^1.1.7"
-                            }
-                        },
-                        "minipass": {
-                            "version": "3.3.6",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "yallist": "^4.0.0"
-                            }
-                        },
-                        "minipass-fetch": {
-                            "version": "2.1.2",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "encoding": "^0.1.13",
-                                "minipass": "^3.1.6",
-                                "minipass-sized": "^1.0.3",
-                                "minizlib": "^2.1.2"
                             }
                         },
                         "nopt": {
@@ -44409,7 +43604,7 @@
                             }
                         },
                         "readable-stream": {
-                            "version": "3.6.1",
+                            "version": "3.6.2",
                             "bundled": true,
                             "dev": true,
                             "requires": {
@@ -44418,29 +43613,10 @@
                                 "util-deprecate": "^1.0.1"
                             }
                         },
-                        "ssri": {
-                            "version": "9.0.1",
+                        "signal-exit": {
+                            "version": "3.0.7",
                             "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "minipass": "^3.1.1"
-                            }
-                        },
-                        "unique-filename": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "unique-slug": "^3.0.0"
-                            }
-                        },
-                        "unique-slug": {
-                            "version": "3.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "imurmurhash": "^0.1.4"
-                            }
+                            "dev": true
                         },
                         "which": {
                             "version": "2.0.2",
@@ -44453,7 +43629,7 @@
                     }
                 },
                 "nopt": {
-                    "version": "7.0.0",
+                    "version": "7.2.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -44472,12 +43648,9 @@
                     }
                 },
                 "npm-audit-report": {
-                    "version": "4.0.0",
+                    "version": "5.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^4.0.0"
-                    }
+                    "dev": true
                 },
                 "npm-bundled": {
                     "version": "3.0.0",
@@ -44488,7 +43661,7 @@
                     }
                 },
                 "npm-install-checks": {
-                    "version": "6.0.0",
+                    "version": "6.1.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -44496,7 +43669,7 @@
                     }
                 },
                 "npm-normalize-package-bin": {
-                    "version": "3.0.0",
+                    "version": "3.0.1",
                     "bundled": true,
                     "dev": true
                 },
@@ -44540,12 +43713,12 @@
                     }
                 },
                 "npm-registry-fetch": {
-                    "version": "14.0.3",
+                    "version": "14.0.5",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "make-fetch-happen": "^11.0.0",
-                        "minipass": "^4.0.0",
+                        "minipass": "^5.0.0",
                         "minipass-fetch": "^3.0.0",
                         "minipass-json-stream": "^1.0.1",
                         "minizlib": "^2.1.2",
@@ -44586,7 +43759,7 @@
                     }
                 },
                 "pacote": {
-                    "version": "15.1.1",
+                    "version": "15.2.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -44596,7 +43769,7 @@
                         "@npmcli/run-script": "^6.0.0",
                         "cacache": "^17.0.0",
                         "fs-minipass": "^3.0.0",
-                        "minipass": "^4.0.0",
+                        "minipass": "^5.0.0",
                         "npm-package-arg": "^10.0.0",
                         "npm-packlist": "^7.0.0",
                         "npm-pick-manifest": "^8.0.0",
@@ -44605,18 +43778,18 @@
                         "promise-retry": "^2.0.1",
                         "read-package-json": "^6.0.0",
                         "read-package-json-fast": "^3.0.0",
-                        "sigstore": "^1.0.0",
+                        "sigstore": "^1.3.0",
                         "ssri": "^10.0.0",
                         "tar": "^6.1.11"
                     }
                 },
                 "parse-conflict-json": {
-                    "version": "3.0.0",
+                    "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "json-parse-even-better-errors": "^3.0.0",
-                        "just-diff": "^5.0.1",
+                        "just-diff": "^6.0.0",
                         "just-diff-apply": "^5.2.0"
                     }
                 },
@@ -44625,8 +43798,29 @@
                     "bundled": true,
                     "dev": true
                 },
+                "path-key": {
+                    "version": "3.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-scurry": {
+                    "version": "1.9.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^9.1.1",
+                        "minipass": "^5.0.0 || ^6.0.2"
+                    },
+                    "dependencies": {
+                        "lru-cache": {
+                            "version": "9.1.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
                 "postcss-selector-parser": {
-                    "version": "6.0.11",
+                    "version": "6.0.13",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -44650,7 +43844,7 @@
                     "dev": true
                 },
                 "promise-call-limit": {
-                    "version": "1.0.1",
+                    "version": "1.0.2",
                     "bundled": true,
                     "dev": true
                 },
@@ -44682,7 +43876,7 @@
                     "dev": true
                 },
                 "read": {
-                    "version": "2.0.0",
+                    "version": "2.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -44695,11 +43889,11 @@
                     "dev": true
                 },
                 "read-package-json": {
-                    "version": "6.0.0",
+                    "version": "6.0.4",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "^8.0.1",
+                        "glob": "^10.2.2",
                         "json-parse-even-better-errors": "^3.0.0",
                         "normalize-package-data": "^5.0.0",
                         "npm-normalize-package-bin": "^3.0.0"
@@ -44715,7 +43909,7 @@
                     }
                 },
                 "readable-stream": {
-                    "version": "4.3.0",
+                    "version": "4.4.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -44771,7 +43965,7 @@
                     }
                 },
                 "safe-buffer": {
-                    "version": "5.1.2",
+                    "version": "5.2.1",
                     "bundled": true,
                     "dev": true
                 },
@@ -44782,7 +43976,7 @@
                     "optional": true
                 },
                 "semver": {
-                    "version": "7.3.8",
+                    "version": "7.5.4",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -44804,19 +43998,32 @@
                     "bundled": true,
                     "dev": true
                 },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
                 "signal-exit": {
-                    "version": "3.0.7",
+                    "version": "4.0.2",
                     "bundled": true,
                     "dev": true
                 },
                 "sigstore": {
-                    "version": "1.1.1",
+                    "version": "1.7.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "@sigstore/protobuf-specs": "^0.1.0",
-                        "make-fetch-happen": "^11.0.1",
-                        "tuf-js": "^1.0.0"
+                        "@sigstore/tuf": "^1.0.1",
+                        "make-fetch-happen": "^11.0.1"
                     }
                 },
                 "smart-buffer": {
@@ -44867,28 +44074,38 @@
                     }
                 },
                 "spdx-license-ids": {
-                    "version": "3.0.12",
+                    "version": "3.0.13",
                     "bundled": true,
                     "dev": true
                 },
                 "ssri": {
-                    "version": "10.0.1",
+                    "version": "10.0.4",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "minipass": "^4.0.0"
+                        "minipass": "^5.0.0"
                     }
                 },
                 "string_decoder": {
-                    "version": "1.1.1",
+                    "version": "1.3.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "~5.2.0"
                     }
                 },
                 "string-width": {
                     "version": "4.2.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.1"
+                    }
+                },
+                "string-width-cjs": {
+                    "version": "npm:string-width@4.2.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -44905,22 +44122,27 @@
                         "ansi-regex": "^5.0.1"
                     }
                 },
-                "supports-color": {
-                    "version": "7.2.0",
+                "strip-ansi-cjs": {
+                    "version": "npm:strip-ansi@6.0.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "has-flag": "^4.0.0"
+                        "ansi-regex": "^5.0.1"
                     }
                 },
+                "supports-color": {
+                    "version": "9.4.0",
+                    "bundled": true,
+                    "dev": true
+                },
                 "tar": {
-                    "version": "6.1.13",
+                    "version": "6.1.15",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "chownr": "^2.0.0",
                         "fs-minipass": "^2.0.0",
-                        "minipass": "^4.0.0",
+                        "minipass": "^5.0.0",
                         "minizlib": "^2.1.1",
                         "mkdirp": "^1.0.3",
                         "yallist": "^4.0.0"
@@ -44962,12 +44184,13 @@
                     "dev": true
                 },
                 "tuf-js": {
-                    "version": "1.1.1",
+                    "version": "1.1.7",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "@tufjs/models": "1.0.0",
-                        "make-fetch-happen": "^11.0.1"
+                        "@tufjs/models": "1.0.4",
+                        "debug": "^4.3.4",
+                        "make-fetch-happen": "^11.1.1"
                     }
                 },
                 "unique-filename": {
@@ -45009,7 +44232,7 @@
                     }
                 },
                 "walk-up-path": {
-                    "version": "1.0.0",
+                    "version": "3.0.1",
                     "bundled": true,
                     "dev": true
                 },
@@ -45022,7 +44245,7 @@
                     }
                 },
                 "which": {
-                    "version": "3.0.0",
+                    "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -45037,18 +44260,73 @@
                         "string-width": "^1.0.2 || 2 || 3 || 4"
                     }
                 },
+                "wrap-ansi": {
+                    "version": "8.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^6.1.0",
+                        "string-width": "^5.0.1",
+                        "strip-ansi": "^7.0.1"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "6.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "ansi-styles": {
+                            "version": "6.2.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "emoji-regex": {
+                            "version": "9.2.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "string-width": {
+                            "version": "5.1.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "eastasianwidth": "^0.2.0",
+                                "emoji-regex": "^9.2.2",
+                                "strip-ansi": "^7.0.1"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "7.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^6.0.1"
+                            }
+                        }
+                    }
+                },
+                "wrap-ansi-cjs": {
+                    "version": "npm:wrap-ansi@7.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true
                 },
                 "write-file-atomic": {
-                    "version": "5.0.0",
+                    "version": "5.0.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "imurmurhash": "^0.1.4",
-                        "signal-exit": "^3.0.7"
+                        "signal-exit": "^4.0.1"
                     }
                 },
                 "yallist": {
@@ -46454,12 +45732,6 @@
                 }
             }
         },
-        "q": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-            "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-            "dev": true
-        },
         "qs": {
             "version": "6.11.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -47420,16 +46692,16 @@
             }
         },
         "semantic-release": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-21.1.1.tgz",
-            "integrity": "sha512-OCIazQnaCHdq1F6zfmKS0P7jZakYq0weiqW2mxUWo4H2CDnxelUoa/0Bs/dQatoHc6JFh6lG2HWpusdl93bFcw==",
+            "version": "22.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-22.0.0-beta.2.tgz",
+            "integrity": "sha512-sPdFctw9g0e0NoCsV1OMMXUQUq16aWPw9BjLvfmHfOJX6Vt/4U7pRlWpCJQXp45KYXUpNmtb1xKZCSdWrCsyng==",
             "dev": true,
             "requires": {
-                "@semantic-release/commit-analyzer": "^10.0.0",
+                "@semantic-release/commit-analyzer": "^11.0.0-beta.1",
                 "@semantic-release/error": "^4.0.0",
                 "@semantic-release/github": "^9.0.0",
                 "@semantic-release/npm": "^10.0.2",
-                "@semantic-release/release-notes-generator": "^11.0.0",
+                "@semantic-release/release-notes-generator": "^12.0.0-beta.1",
                 "aggregate-error": "^4.0.1",
                 "cosmiconfig": "^8.0.0",
                 "debug": "^4.0.0",
@@ -47455,11 +46727,112 @@
                 "yargs": "^17.5.1"
             },
             "dependencies": {
+                "@semantic-release/commit-analyzer": {
+                    "version": "11.0.0-beta.1",
+                    "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-11.0.0-beta.1.tgz",
+                    "integrity": "sha512-4HOXQ09k/lnHwxQLD9y1c+b3rA2M4gWA/twJl9JuRqS1eXrEc9QJ903reN5nwEC0Y7TVpuDTd1cY90B6W9EITw==",
+                    "dev": true,
+                    "requires": {
+                        "conventional-changelog-angular": "^7.0.0",
+                        "conventional-commits-filter": "^3.0.0",
+                        "conventional-commits-parser": "^5.0.0",
+                        "debug": "^4.0.0",
+                        "import-from": "^4.0.0",
+                        "lodash-es": "^4.17.21",
+                        "micromatch": "^4.0.2"
+                    }
+                },
                 "@semantic-release/error": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
                     "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
                     "dev": true
+                },
+                "@semantic-release/github": {
+                    "version": "9.0.4",
+                    "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.0.4.tgz",
+                    "integrity": "sha512-kQCGFAsBErvCR6hzNuzu63cj4erQN2krm9zQlg8vl4j5X0mL0d/Ras0wmL5Gkr1TuSS2lweME7M4J5zvtDDDSA==",
+                    "dev": true,
+                    "requires": {
+                        "@octokit/core": "^5.0.0",
+                        "@octokit/plugin-paginate-rest": "^8.0.0",
+                        "@octokit/plugin-retry": "^6.0.0",
+                        "@octokit/plugin-throttling": "^7.0.0",
+                        "@semantic-release/error": "^4.0.0",
+                        "aggregate-error": "^4.0.1",
+                        "debug": "^4.3.4",
+                        "dir-glob": "^3.0.1",
+                        "globby": "^13.1.4",
+                        "http-proxy-agent": "^7.0.0",
+                        "https-proxy-agent": "^7.0.0",
+                        "issue-parser": "^6.0.0",
+                        "lodash-es": "^4.17.21",
+                        "mime": "^3.0.0",
+                        "p-filter": "^3.0.0",
+                        "url-join": "^5.0.0"
+                    }
+                },
+                "@semantic-release/npm": {
+                    "version": "10.0.5",
+                    "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-10.0.5.tgz",
+                    "integrity": "sha512-cJnQ2M5pxJRwZEkb0A/+U3TG4UNmjrrLwV2PxJKljn5OPT0yJB8GzGgWbbKACayvxrT06YdTa4Amtq/piJcOIA==",
+                    "dev": true,
+                    "requires": {
+                        "@semantic-release/error": "^4.0.0",
+                        "aggregate-error": "^4.0.1",
+                        "execa": "^8.0.0",
+                        "fs-extra": "^11.0.0",
+                        "lodash-es": "^4.17.21",
+                        "nerf-dart": "^1.0.0",
+                        "normalize-url": "^8.0.0",
+                        "npm": "^9.5.0",
+                        "rc": "^1.2.8",
+                        "read-pkg": "^8.0.0",
+                        "registry-auth-token": "^5.0.0",
+                        "semver": "^7.1.2",
+                        "tempy": "^3.0.0"
+                    }
+                },
+                "@semantic-release/release-notes-generator": {
+                    "version": "12.0.0-beta.1",
+                    "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-12.0.0-beta.1.tgz",
+                    "integrity": "sha512-VKkXO4FXPP/nX90/9M1vGI9oMPpKOqYdeDl7hM5dAnNa7X1gC4hE2bZC8vqojHtQaf2tHIyGHZH186F5LwNRDA==",
+                    "dev": true,
+                    "requires": {
+                        "conventional-changelog-angular": "^7.0.0",
+                        "conventional-changelog-writer": "^6.0.0",
+                        "conventional-commits-filter": "^4.0.0",
+                        "conventional-commits-parser": "^5.0.0",
+                        "debug": "^4.0.0",
+                        "get-stream": "^7.0.0",
+                        "import-from": "^4.0.0",
+                        "into-stream": "^7.0.0",
+                        "lodash-es": "^4.17.21",
+                        "read-pkg-up": "^10.0.0"
+                    },
+                    "dependencies": {
+                        "conventional-commits-filter": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
+                            "integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
+                            "dev": true
+                        },
+                        "get-stream": {
+                            "version": "7.0.1",
+                            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
+                            "integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
+                            "dev": true
+                        }
+                    }
+                },
+                "agent-base": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+                    "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^4.3.4"
+                    }
                 },
                 "aggregate-error": {
                     "version": "4.0.1",
@@ -47478,6 +46851,23 @@
                     "dev": true,
                     "requires": {
                         "escape-string-regexp": "5.0.0"
+                    }
+                },
+                "crypto-random-string": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+                    "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "type-fest": {
+                            "version": "1.4.0",
+                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+                            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+                            "dev": true
+                        }
                     }
                 },
                 "escape-string-regexp": {
@@ -47521,6 +46911,19 @@
                         "path-exists": "^5.0.0"
                     }
                 },
+                "globby": {
+                    "version": "13.2.2",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+                    "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+                    "dev": true,
+                    "requires": {
+                        "dir-glob": "^3.0.1",
+                        "fast-glob": "^3.3.0",
+                        "ignore": "^5.2.4",
+                        "merge2": "^1.4.1",
+                        "slash": "^4.0.0"
+                    }
+                },
                 "hosted-git-info": {
                     "version": "7.0.0",
                     "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.0.tgz",
@@ -47528,6 +46931,26 @@
                     "dev": true,
                     "requires": {
                         "lru-cache": "^10.0.1"
+                    }
+                },
+                "http-proxy-agent": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+                    "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^7.1.0",
+                        "debug": "^4.3.4"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "7.0.2",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+                    "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^7.0.2",
+                        "debug": "4"
                     }
                 },
                 "human-signals": {
@@ -47697,6 +47120,106 @@
                         "type-fest": "^4.2.0"
                     }
                 },
+                "semantic-release": {
+                    "version": "21.1.1",
+                    "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-21.1.1.tgz",
+                    "integrity": "sha512-OCIazQnaCHdq1F6zfmKS0P7jZakYq0weiqW2mxUWo4H2CDnxelUoa/0Bs/dQatoHc6JFh6lG2HWpusdl93bFcw==",
+                    "dev": true,
+                    "peer": true,
+                    "requires": {
+                        "@semantic-release/commit-analyzer": "^10.0.0",
+                        "@semantic-release/error": "^4.0.0",
+                        "@semantic-release/github": "^9.0.0",
+                        "@semantic-release/npm": "^10.0.2",
+                        "@semantic-release/release-notes-generator": "^11.0.0",
+                        "aggregate-error": "^4.0.1",
+                        "cosmiconfig": "^8.0.0",
+                        "debug": "^4.0.0",
+                        "env-ci": "^9.0.0",
+                        "execa": "^8.0.0",
+                        "figures": "^5.0.0",
+                        "find-versions": "^5.1.0",
+                        "get-stream": "^6.0.0",
+                        "git-log-parser": "^1.2.0",
+                        "hook-std": "^3.0.0",
+                        "hosted-git-info": "^7.0.0",
+                        "lodash-es": "^4.17.21",
+                        "marked": "^5.0.0",
+                        "marked-terminal": "^5.1.1",
+                        "micromatch": "^4.0.2",
+                        "p-each-series": "^3.0.0",
+                        "p-reduce": "^3.0.0",
+                        "read-pkg-up": "^10.0.0",
+                        "resolve-from": "^5.0.0",
+                        "semver": "^7.3.2",
+                        "semver-diff": "^4.0.0",
+                        "signale": "^1.2.1",
+                        "yargs": "^17.5.1"
+                    },
+                    "dependencies": {
+                        "@semantic-release/commit-analyzer": {
+                            "version": "10.0.4",
+                            "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-10.0.4.tgz",
+                            "integrity": "sha512-pFGn99fn8w4/MHE0otb2A/l5kxgOuxaaauIh4u30ncoTJuqWj4hXTgEJ03REqjS+w1R2vPftSsO26WC61yOcpw==",
+                            "dev": true,
+                            "peer": true,
+                            "requires": {
+                                "conventional-changelog-angular": "^6.0.0",
+                                "conventional-commits-filter": "^3.0.0",
+                                "conventional-commits-parser": "^5.0.0",
+                                "debug": "^4.0.0",
+                                "import-from": "^4.0.0",
+                                "lodash-es": "^4.17.21",
+                                "micromatch": "^4.0.2"
+                            }
+                        },
+                        "@semantic-release/release-notes-generator": {
+                            "version": "11.0.7",
+                            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-11.0.7.tgz",
+                            "integrity": "sha512-T09QB9ImmNx7Q6hY6YnnEbw/rEJ6a+22LBxfZq+pSAXg/OL/k0siwEm5cK4k1f9dE2Z2mPIjJKKohzUm0jbxcQ==",
+                            "dev": true,
+                            "peer": true,
+                            "requires": {
+                                "conventional-changelog-angular": "^6.0.0",
+                                "conventional-changelog-writer": "^6.0.0",
+                                "conventional-commits-filter": "^4.0.0",
+                                "conventional-commits-parser": "^5.0.0",
+                                "debug": "^4.0.0",
+                                "get-stream": "^7.0.0",
+                                "import-from": "^4.0.0",
+                                "into-stream": "^7.0.0",
+                                "lodash-es": "^4.17.21",
+                                "read-pkg-up": "^10.0.0"
+                            },
+                            "dependencies": {
+                                "conventional-commits-filter": {
+                                    "version": "4.0.0",
+                                    "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
+                                    "integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
+                                    "dev": true,
+                                    "peer": true
+                                },
+                                "get-stream": {
+                                    "version": "7.0.1",
+                                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
+                                    "integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
+                                    "dev": true,
+                                    "peer": true
+                                }
+                            }
+                        },
+                        "conventional-changelog-angular": {
+                            "version": "6.0.0",
+                            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
+                            "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
+                            "dev": true,
+                            "peer": true,
+                            "requires": {
+                                "compare-func": "^2.0.0"
+                            }
+                        }
+                    }
+                },
                 "semver": {
                     "version": "7.5.4",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -47723,11 +47246,52 @@
                     "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
                     "dev": true
                 },
+                "slash": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+                    "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+                    "dev": true
+                },
                 "strip-final-newline": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
                     "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
                     "dev": true
+                },
+                "temp-dir": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+                    "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+                    "dev": true
+                },
+                "tempy": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+                    "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+                    "dev": true,
+                    "requires": {
+                        "is-stream": "^3.0.0",
+                        "temp-dir": "^3.0.0",
+                        "type-fest": "^2.12.2",
+                        "unique-string": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "type-fest": {
+                            "version": "2.19.0",
+                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+                            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+                            "dev": true
+                        }
+                    }
+                },
+                "unique-string": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+                    "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+                    "dev": true,
+                    "requires": {
+                        "crypto-random-string": "^4.0.0"
+                    }
                 },
                 "yallist": {
                     "version": "4.0.0",
@@ -48102,13 +47666,10 @@
             }
         },
         "split2": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-            "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-            "dev": true,
-            "requires": {
-                "readable-stream": "^3.0.0"
-            }
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+            "dev": true
         },
         "sprintf-js": {
             "version": "1.0.3",
@@ -48727,9 +48288,9 @@
             }
         },
         "text-extensions": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
-            "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
+            "integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
             "dev": true
         },
         "text-table": {
@@ -48748,15 +48309,6 @@
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
             "dev": true
-        },
-        "through2": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-            "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-            "dev": true,
-            "requires": {
-                "readable-stream": "3"
-            }
         },
         "tiny-glob": {
             "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
         "react-markdown": "8.0.7",
         "react-syntax-highlighter": "15.5.0",
         "rimraf": "5.0.1",
-        "semantic-release": "21.1.1",
+        "semantic-release": "22.0.0-beta.2",
         "storybook": "7.4.0",
         "storybook-css-modules": "1.0.8",
         "type-fest": "4.3.1",


### PR DESCRIPTION
## Overview

Bumps `semantic-release` to the latest beta (as suggested [here](https://github.com/semantic-release/semantic-release/issues/2929#issuecomment-1703386961)) in an attempt to fix https://github.com/semantic-release/semantic-release/issues/2932 (which is currently preventing us from publishing new Typist releases).

> **Note**
> This PR also enables manual triggers for the `Typist Package Release` workflow so that we can test that all is working. The `workflow_dispatch` trigger should be removed once everything is working without issues.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

This needs to be merged and [this workflow](https://github.com/Doist/typist/actions/workflows/publish-typist-package-release.yml) manually triggered to properly test that this is working.