### PR TITLE
chore(deps): revert dependency conventional-changelog-conventionalcommits to v6.1.0

### DIFF
--- a/.github/workflows/publish-typist-package-release.yml
+++ b/.github/workflows/publish-typist-package-release.yml
@@ -1,6 +1,7 @@
 name: Typist Package Release
 
 on:
+    workflow_dispatch:
     workflow_run:
         workflows:
             - CI Validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
                 "@vitejs/plugin-react": "4.0.4",
                 "boring-avatars": "1.10.1",
                 "classnames": "2.3.2",
-                "conventional-changelog-conventionalcommits": "7.0.1",
+                "conventional-changelog-conventionalcommits": "6.1.0",
                 "emoji-regex": "10.2.1",
                 "eslint": "8.48.0",
                 "eslint-formatter-codeframe": "7.32.1",
@@ -11502,15 +11502,15 @@
             }
         },
         "node_modules/conventional-changelog-conventionalcommits": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.1.tgz",
-            "integrity": "sha512-VfFJxBmi+LYXeb4pIfZGbuaFCpWZh0qXbUAKP/s6B8tigV6R4D8j5PDlTtMMWawa7+DcNySVoF7kPWz0EMYuCQ==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.1.0.tgz",
+            "integrity": "sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==",
             "dev": true,
             "dependencies": {
                 "compare-func": "^2.0.0"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=14"
             }
         },
         "node_modules/conventional-changelog-writer": {
@@ -37059,9 +37059,9 @@
             }
         },
         "conventional-changelog-conventionalcommits": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.1.tgz",
-            "integrity": "sha512-VfFJxBmi+LYXeb4pIfZGbuaFCpWZh0qXbUAKP/s6B8tigV6R4D8j5PDlTtMMWawa7+DcNySVoF7kPWz0EMYuCQ==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.1.0.tgz",
+            "integrity": "sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==",
             "dev": true,
             "requires": {
                 "compare-func": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
         "@vitejs/plugin-react": "4.0.4",
         "boring-avatars": "1.10.1",
         "classnames": "2.3.2",
-        "conventional-changelog-conventionalcommits": "7.0.1",
+        "conventional-changelog-conventionalcommits": "6.1.0",
         "emoji-regex": "10.2.1",
         "eslint": "8.48.0",
         "eslint-formatter-codeframe": "7.32.1",


### PR DESCRIPTION
## Overview

Unfortunately, https://github.com/Doist/typist/pull/429 does not work because [dependency resolutions fails](https://github.com/Doist/typist/actions/runs/6083324997/job/16502970307?pr=429), and while it would likely still work if we forced it, it doesn't feel like the right course of action.

Instead, to fix https://github.com/semantic-release/semantic-release/issues/2932, we are reverting the dependency that is actually causing issues. Once the new stable version of `semantic-release` is released, we can upgrade `conventional-changelog-conventionalcommits` to v7 again.

> **Note**
> This PR also enables manual triggers for the `Typist Package Release` workflow so that we can test that all is working. The `workflow_dispatch` trigger should be removed once everything is working without issues.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

This needs to be merged, and [this workflow](https://github.com/Doist/typist/actions/workflows/publish-typist-package-release.yml) manually triggered to properly test that this is working.