### PR TITLE
chore: Remove manual trigger from `Typist Package Release` workflow

### DIFF
--- a/.github/workflows/publish-typist-package-release.yml
+++ b/.github/workflows/publish-typist-package-release.yml
@@ -1,7 +1,6 @@
 name: Typist Package Release
 
 on:
-    workflow_dispatch:
     workflow_run:
         workflows:
             - CI Validation


### PR DESCRIPTION
## Overview

The fix in https://github.com/Doist/typist/pull/430 worked as expected, and a new release was published successfully, which means we no longer need `workflow_dispatch`. In fact, that was never needed in the first place, because each push to `main` triggers the `Typist Package Release` workflow anyway.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

There's nothing to test here, just cleaning up temporary changes.