### PR TITLE
fix: Remove `handlePaste` escape when clipboard holds multiple types

### DIFF
--- a/src/extensions/rich-text/rich-text-image.ts
+++ b/src/extensions/rich-text/rich-text-image.ts
@@ -185,11 +185,6 @@ const RichTextImage = Image.extend<RichTextImageOptions>({
                             return false
                         }
 
-                        // Do not handle the event if there are multiple clipboard types
-                        if ((event.clipboardData?.types || []).length > 1) {
-                            return false
-                        }
-
                         const pastedFiles = Array.from(event.clipboardData?.files || [])
 
                         // Do not handle the event if no files were pasted


### PR DESCRIPTION
<!-- Thank you for your contribution to the Typist repository. -->

<!-- Please remove all sections that are not relevant. -->

## Overview

Closes https://github.com/Doist/typist/issues/397

In https://github.com/Doist/typist/pull/290, we tried to support pasting tables from [Numbers](https://www.apple.com/ca/numbers/) more predictable by discarding the image from the clipboard when it holds multiple types, however, this also affected copying an image from the browser, as it puts both images and some HTML data on the clipboard. Here, we revert the change so that the `RichTextImage` extension is allowed handle cases with multiple clipboard types again.

## PR Checklist

<!-- Feel free to remove the lines that are not applicable or leave them unchecked. -->

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
-   [ ] Added/updated unit test cases and/or end-to-end test cases
-   [ ] Added/updated documentation to Storybook or `README.md`

## Test plan

- [x] Copy some spreadsheet data from Numbers and paste it into the editor. You should see an image of the table being added to the content, with a datauri as the image link in markdown
- [x] Paste the same spreadsheet data using `shift + cmd + v`. You should see a the data in the editor's content formatted with the correct line breaks and spacing. You should not see it formatted as a markdown or HTML table
- [x] Copy an image from the browser and paste it into the editor. You should see the image in the editor, and a datauri for the image in markdown

## Demo

| Before                      | After                      |
| --------------------------- | -------------------------- |
| ![image](https://github.com/Doist/typist/assets/8531248/19537188-11b5-440c-ac26-91e092ec399d) | ![image](https://github.com/Doist/typist/assets/8531248/95d67836-0ba3-416f-a757-01a4411351ca) |
