### PR TITLE
fix: Hyperlink a text selection when pasting a valid URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,6 +107,7 @@
                 "@react-hookz/web": "^14.2.3 || >=15.x",
                 "emoji-regex": "^10.2.1",
                 "hast-util-is-element": "^2.1.0",
+                "linkifyjs": "^4.1.1",
                 "lodash-es": "^4.17.21",
                 "mdast-util-gfm-autolink-literal": "^1.0.0",
                 "mdast-util-gfm-strikethrough": "^1.0.0",
@@ -17479,9 +17480,9 @@
             }
         },
         "node_modules/linkifyjs": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.1.0.tgz",
-            "integrity": "sha512-Ffv8VoY3+ixI1b3aZ3O+jM6x17cOsgwfB1Wq7pkytbo1WlyRp6ZO0YDMqiWT/gQPY/CmtiGuKfzDIVqxh1aCTA=="
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.1.1.tgz",
+            "integrity": "sha512-zFN/CTVmbcVef+WaDXT63dNzzkfRBKT1j464NJQkV7iSgJU0sLBus9W0HBwnXK13/hf168pbrx/V/bjEHOXNHA=="
         },
         "node_modules/lint-staged": {
             "version": "14.0.1",
@@ -41517,9 +41518,9 @@
             }
         },
         "linkifyjs": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.1.0.tgz",
-            "integrity": "sha512-Ffv8VoY3+ixI1b3aZ3O+jM6x17cOsgwfB1Wq7pkytbo1WlyRp6ZO0YDMqiWT/gQPY/CmtiGuKfzDIVqxh1aCTA=="
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.1.1.tgz",
+            "integrity": "sha512-zFN/CTVmbcVef+WaDXT63dNzzkfRBKT1j464NJQkV7iSgJU0sLBus9W0HBwnXK13/hf168pbrx/V/bjEHOXNHA=="
         },
         "lint-staged": {
             "version": "14.0.1",

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
         "rehype-minify-whitespace": "^5.0.0",
         "rehype-raw": "^6.1.0",
         "rehype-stringify": "^9.0.0",
+        "linkifyjs": "^4.1.1",
         "remark": "^14.0.0",
         "remark-breaks": "^3.0.0",
         "remark-gfm": "^3.0.0",

--- a/src/constants/extension-priorities.ts
+++ b/src/constants/extension-priorities.ts
@@ -3,7 +3,21 @@
  * be higher than most extensions, so that event handlers from the dropdown render function can take
  * precedence over all other event handlers in the chain.
  */
-const SUGGESTION_EXTENSION_PRIORITY = 1000
+const SUGGESTION_EXTENSION_PRIORITY = 10000
+
+/**
+ * Priority for the `PasteHTMLTableAsString` extension. This needs to be higher than most paste
+ * extensions (e.g., `PasteSinglelineText`, `PasteMarkdown`, etc.), so that the extension can first
+ * parse HTML tables that might exist in the clipboard data.
+ */
+const PASTE_HTML_TABLE_AS_STRING_EXTENSION_PRIORITY = 1005
+
+/**
+ * Priority for the `PasteMarkdown` extension. This needs to be higher than the built-in and
+ * official `Link` extension (i.e. `1000`), so that the extension can first parse Markdown links
+ * correctly, without having the `Link` extension paste handlers interfering.
+ */
+const PASTE_MARKDOWN_EXTENSION_PRIORITY = 1001
 
 /**
  * Priority for the `SmartMarkdownTyping` extension. This needs to be higher than the
@@ -11,13 +25,6 @@ const SUGGESTION_EXTENSION_PRIORITY = 1000
  * extension can take precedence over the `ViewEventHandlers` extension event handlers.
  */
 const SMART_MARKDOWN_TYPING_PRIORITY = 110
-
-/**
- * Priority for the `PasteHTMLTableAsString` extension. This needs to be higher than most paste
- * extensions (e.g., `PasteSinglelineText`, `PasteMarkdown`, etc.), so that the extension can first
- * parse HTML tables that might exist in the clipboard data.
- */
-const PASTE_EXTENSION_PRIORITY = 105
 
 /**
  * Priority for the `ViewEventHandlers` extension. This needs to be higher than the default for most
@@ -43,7 +50,8 @@ const CODE_EXTENSION_PRIORITY = 99
 export {
     BLOCKQUOTE_EXTENSION_PRIORITY,
     CODE_EXTENSION_PRIORITY,
-    PASTE_EXTENSION_PRIORITY,
+    PASTE_HTML_TABLE_AS_STRING_EXTENSION_PRIORITY,
+    PASTE_MARKDOWN_EXTENSION_PRIORITY,
     SMART_MARKDOWN_TYPING_PRIORITY,
     SUGGESTION_EXTENSION_PRIORITY,
     VIEW_EVENT_HANDLERS_PRIORITY,

--- a/src/extensions/rich-text/rich-text-link.ts
+++ b/src/extensions/rich-text/rich-text-link.ts
@@ -57,31 +57,12 @@ function linkPasteRule(config: Parameters<typeof markPasteRule>[0]) {
 }
 
 /**
- * The options available to customize the `RichTextLink` extension.
- */
-type RichTextLinkOptions = Omit<
-    LinkOptions,
-    // The `linkOnPaste` option is not available in the `RichTextLink` extension, since we're using
-    // our own paste rules to handle Markdown syntax (see `addOptions` below)
-    'linkOnPaste'
->
-
-/**
  * Custom extension that extends the built-in `Link` extension to add additional input/paste rules
  * for converting the Markdown link syntax (i.e. `[Doist](https://doist.com)`) into links, and also
  * adds support for the `title` attribute.
  */
-const RichTextLink = Link.extend<RichTextLinkOptions>({
+const RichTextLink = Link.extend({
     inclusive: false,
-    addOptions() {
-        return {
-            ...this.parent?.(),
-            // Disable the built-in auto-linking feature for pasted URLs, since we're using our own
-            // paste rules to handle Markdown syntax (on top of that, the `PasteMarkdown` extension
-            // takes precedence, and will handle auto-linking for pasted URLs anyway)
-            linkOnPaste: false,
-        }
-    },
     addAttributes() {
         return {
             ...this.parent?.(),
@@ -130,4 +111,4 @@ const RichTextLink = Link.extend<RichTextLinkOptions>({
 
 export { RichTextLink }
 
-export type { RichTextLinkOptions }
+export type { LinkOptions as RichTextLinkOptions }

--- a/src/extensions/shared/paste-html-table-as-string.ts
+++ b/src/extensions/shared/paste-html-table-as-string.ts
@@ -1,7 +1,7 @@
 import { Extension } from '@tiptap/core'
 import { Plugin, PluginKey } from 'prosemirror-state'
 
-import { PASTE_EXTENSION_PRIORITY } from '../../constants/extension-priorities'
+import { PASTE_HTML_TABLE_AS_STRING_EXTENSION_PRIORITY } from '../../constants/extension-priorities'
 import { parseHtmlToElement } from '../../helpers/dom'
 
 /**
@@ -18,7 +18,7 @@ import { parseHtmlToElement } from '../../helpers/dom'
  */
 const PasteHTMLTableAsString = Extension.create({
     name: 'pasteHTMLTableAsString',
-    priority: PASTE_EXTENSION_PRIORITY,
+    priority: PASTE_HTML_TABLE_AS_STRING_EXTENSION_PRIORITY,
     addProseMirrorPlugins() {
         return [
             new Plugin({

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export type {
     UpdateProps,
 } from './components/typist-editor'
 export { TypistEditor } from './components/typist-editor'
-export { SUGGESTION_EXTENSION_PRIORITY } from './constants/extension-priorities'
+export * from './constants/extension-priorities'
 export * from './extensions/core/extra-editor-commands/commands/extend-word-range'
 export * from './extensions/core/extra-editor-commands/commands/insert-markdown-content'
 export { PlainTextKit } from './extensions/plain-text/plain-text-kit'


### PR DESCRIPTION
## Overview

This PR closes https://github.com/Doist/typist/issues/423 with an implementation that does not require an upstream fix, one that increases the priority for our custom "paste extensions", making sure they are above the built-in `Link` extension. This will make sure that our handlers kick-in first, handling Markdown if and when appropriate. On top of that, it will check if the content being pasted is a valid URL, and if it is, let the built-in handlers do their thing (thus fixing https://github.com/Doist/typist/issues/423).

This approach will fix most of our sides - but not all - with a more consistent and predicable approach, which will make it easier to debug other issues that we have or might end up having in the future.

> **Note**
> For the detection of valid URLs I'm using the [`linkifyjs`](https://linkify.js.org/) library, something that Tiptap already uses internally, so we are not increasing the bundle. I'm just making it an explicit peer dependency, so that it can also be used in our products without dependency issues.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Type a simple Markdown link (i.e. `[some text](https://example.com)`
- Type a Markdown link with title (i.e. `[some text](https://example.com "EXAMPLE")`
- Copy `[some text](https://example.com)` and paste into the editor (with `Ctrl/Cmd + Shift + V`)
- Copy `[some text](https://example.com "EXAMPLE")` and paste into the editor (with `Ctrl/Cmd + Shift + V`)
- Copy `[message link](message://%3cDM6PR05MB4777270E5C7A734F56BC519A9BE0A@DM6PR05MB4777.example.com%3e)` and paste into the editor (with `Ctrl/Cmd + Shift + V`)
- Type some text, make sure it's not hyperlinked, select that text, and paste a URL on the selection (try multiple URLs, like valid public ones, localhost ones, `message://` ones, simple ones like `example.com`)