### PR TITLE
feat(commands)!: Add `insertMarkdownContentAt` command

### DIFF
--- a/src/extensions/core/extra-editor-commands/commands/insert-markdown-content-at.ts
+++ b/src/extensions/core/extra-editor-commands/commands/insert-markdown-content-at.ts
@@ -1,0 +1,101 @@
+import { RawCommands, selectionToInsertionEnd } from '@tiptap/core'
+import { DOMParser } from 'prosemirror-model'
+
+import { parseHtmlToElement } from '../../../../helpers/dom'
+import { getHTMLSerializerInstance } from '../../../../serializers/html/html'
+
+import type { Range } from '@tiptap/core'
+import type { ParseOptions } from 'prosemirror-model'
+
+/**
+ * Augment the official `@tiptap/core` module with extra commands so that the compiler knows about
+ * them. For this to work externally, a wildcard export needs to be added to the root `index.ts`.
+ */
+declare module '@tiptap/core' {
+    interface Commands<ReturnType> {
+        insertMarkdownContentAt: {
+            /**
+             * Inserts the provided Markdown content as HTML into the editor at a specific position.
+             *
+             * @param position The position or range the Markdown will be inserted in.
+             * @param markdown The Markdown content to parse and insert as HTML.
+             * @param options An optional object with the following parameters:
+             * @param options.parseOptions The parse options to use when the HTML content is parsed by ProseMirror.
+             * @param options.updateSelection Whether the selection should move to the newly inserted content.
+             */
+            insertMarkdownContentAt: (
+                position: number | Range,
+                markdown: string,
+                options?: {
+                    parseOptions?: ParseOptions
+                    updateSelection?: boolean
+                },
+            ) => ReturnType
+        }
+    }
+}
+
+/**
+ * Inserts the provided Markdown content as HTML into the editor at a specific position.
+ *
+ * The solution for this function was inspired by how ProseMirror pastes content from the clipboard,
+ * and how Tiptap inserts content with the `insertContentAt` command.
+ */
+function insertMarkdownContentAt(
+    position: number | Range,
+    markdown: string,
+    options?: {
+        parseOptions?: ParseOptions
+        updateSelection?: boolean
+    },
+): ReturnType<RawCommands['insertMarkdownContentAt']> {
+    return ({ editor, tr, dispatch }) => {
+        // Check if the transaction should be dispatched
+        // ref: https://tiptap.dev/api/commands#dry-run-for-commands
+        if (dispatch) {
+            // Default values for command options must be set here
+            // (they do not work if set in the function signature)
+            options = {
+                parseOptions: {},
+                updateSelection: true,
+                ...options,
+            }
+
+            // Get the start and end positions from the provided position
+            let { from, to } =
+                typeof position === 'number'
+                    ? { from: position, to: position }
+                    : { from: position.from, to: position.to }
+
+            // If the selection is empty, and we're in an empty textblock, expand the start and end
+            // positions to include the whole textblock (not leaving empty paragraphs behind)
+            if (from === to) {
+                const { parent } = tr.doc.resolve(from)
+
+                if (parent.isTextblock && parent.childCount === 0) {
+                    from -= 1
+                    to += 1
+                }
+            }
+
+            // Parse the Markdown to HTML and then then into ProseMirror nodes
+            const htmlContent = getHTMLSerializerInstance(editor.schema).serialize(markdown)
+            const content = DOMParser.fromSchema(editor.schema).parse(
+                parseHtmlToElement(htmlContent),
+                options.parseOptions,
+            )
+
+            // Inserts the content into the editor while preserving the current selection
+            tr.replaceWith(from, to, content)
+
+            // Set the text cursor to the end of the inserted content
+            if (options.updateSelection) {
+                selectionToInsertionEnd(tr, tr.steps.length - 1, -1)
+            }
+        }
+
+        return true
+    }
+}
+
+export { insertMarkdownContentAt }

--- a/src/extensions/core/extra-editor-commands/extra-editor-commands.ts
+++ b/src/extensions/core/extra-editor-commands/extra-editor-commands.ts
@@ -3,6 +3,7 @@ import { Extension } from '@tiptap/core'
 import { createParagraphEnd } from './commands/create-paragraph-end'
 import { extendWordRange } from './commands/extend-word-range'
 import { insertMarkdownContent } from './commands/insert-markdown-content'
+import { insertMarkdownContentAt } from './commands/insert-markdown-content-at'
 
 /**
  * The `ExtraEditorCommands` extension is a collection of editor commands that provide additional
@@ -16,6 +17,7 @@ const ExtraEditorCommands = Extension.create({
             createParagraphEnd,
             extendWordRange,
             insertMarkdownContent,
+            insertMarkdownContentAt,
         }
     },
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export * from './constants/extension-priorities'
 export * from './extensions/core/extra-editor-commands/commands/create-paragraph-end'
 export * from './extensions/core/extra-editor-commands/commands/extend-word-range'
 export * from './extensions/core/extra-editor-commands/commands/insert-markdown-content'
+export * from './extensions/core/extra-editor-commands/commands/insert-markdown-content-at'
 export { PlainTextKit } from './extensions/plain-text/plain-text-kit'
 export type {
     RichTextImageAttributes,

--- a/stories/typist-editor/constants/markdown.ts
+++ b/stories/typist-editor/constants/markdown.ts
@@ -3,7 +3,7 @@
  *
  * @see https://jaspervdj.be/lorem-markdownum/
  */
-const MARKDOWN_PLACEHOLDER = `# Volucrum operisque praepetis distulit
+const MARKDOWN_PLACEHOLDER_LONG = `# Volucrum operisque praepetis distulit
 
 ## Et sponte tamen
 
@@ -48,4 +48,10 @@ python_cisc.smartSurfaceLeopard.encryptionOop(permalinkHardError - primary * tec
 
 Erubuit cum caruisse et **passim** mentesque nulla, vox deus, est ut quis iracunda Propoetidas? Velis adeste parentis vincere, [opem](http://passis-locum.io/saepe), quos acceptaque atque.`
 
-export { MARKDOWN_PLACEHOLDER }
+const MARKDOWN_PLACEHOLDER_SHORT = `> ### Duobus concita cum
+>
+> Simul saevo subcrescit **aetherias non** Pisaeae Mater inquit miserabilis
+attolle muneris mundi *vivacisque accepisse*. Petit ad nullo omni carbasa,
+peccavimus [essem](http://incidere.com/) monte fluxerunt caeruleos subito.`
+
+export { MARKDOWN_PLACEHOLDER_LONG, MARKDOWN_PLACEHOLDER_SHORT }

--- a/stories/typist-editor/plain-text-functions.stories.tsx
+++ b/stories/typist-editor/plain-text-functions.stories.tsx
@@ -3,11 +3,12 @@ import { useCallback, useRef } from 'react'
 import { Button } from '@doist/reactist'
 
 import { action } from '@storybook/addon-actions'
+import { Selection } from '@tiptap/pm/state'
 
 import { TypistEditor, TypistEditorRef } from '../../src'
 
 import { DEFAULT_ARG_TYPES } from './constants/defaults'
-import { MARKDOWN_PLACEHOLDER } from './constants/markdown'
+import { MARKDOWN_PLACEHOLDER_LONG, MARKDOWN_PLACEHOLDER_SHORT } from './constants/markdown'
 import { TypistEditorDecorator } from './decorators/typist-editor-decorator/typist-editor-decorator'
 import { Default } from './plain-text.stories'
 
@@ -41,7 +42,19 @@ export const Commands: StoryObj<typeof TypistEditor> = {
                     ?.getEditor()
                     .chain()
                     .focus()
-                    .insertMarkdownContent(MARKDOWN_PLACEHOLDER)
+                    .insertMarkdownContent(MARKDOWN_PLACEHOLDER_LONG)
+                    .run()
+            }, [])
+
+            const handleInsertMarkdownContentAtClick = useCallback(() => {
+                typistEditorRef.current
+                    ?.getEditor()
+                    .chain()
+                    .focus()
+                    .insertMarkdownContentAt(
+                        Selection.atEnd(typistEditorRef.current?.getEditor().state.doc),
+                        MARKDOWN_PLACEHOLDER_SHORT,
+                    )
                     .run()
             }, [])
 
@@ -64,6 +77,12 @@ export const Commands: StoryObj<typeof TypistEditor> = {
                                     onClick={handleInsertMarkdownContentClick}
                                 >
                                     insertMarkdownContent
+                                </Button>
+                                <Button
+                                    variant="secondary"
+                                    onClick={handleInsertMarkdownContentAtClick}
+                                >
+                                    insertMarkdownContentAt
                                 </Button>
                             </>
                         )

--- a/stories/typist-editor/rich-text-functions.stories.tsx
+++ b/stories/typist-editor/rich-text-functions.stories.tsx
@@ -3,11 +3,12 @@ import { useCallback, useRef } from 'react'
 import { Button } from '@doist/reactist'
 
 import { action } from '@storybook/addon-actions'
+import { Selection } from '@tiptap/pm/state'
 
 import { TypistEditor, TypistEditorRef } from '../../src'
 
 import { DEFAULT_ARG_TYPES } from './constants/defaults'
-import { MARKDOWN_PLACEHOLDER } from './constants/markdown'
+import { MARKDOWN_PLACEHOLDER_LONG, MARKDOWN_PLACEHOLDER_SHORT } from './constants/markdown'
 import { TypistEditorDecorator } from './decorators/typist-editor-decorator/typist-editor-decorator'
 import { Default } from './rich-text.stories'
 
@@ -41,7 +42,19 @@ export const Commands: StoryObj<typeof TypistEditor> = {
                     ?.getEditor()
                     .chain()
                     .focus()
-                    .insertMarkdownContent(MARKDOWN_PLACEHOLDER)
+                    .insertMarkdownContent(MARKDOWN_PLACEHOLDER_LONG)
+                    .run()
+            }, [])
+
+            const handleInsertMarkdownContentAtClick = useCallback(() => {
+                typistEditorRef.current
+                    ?.getEditor()
+                    .chain()
+                    .focus()
+                    .insertMarkdownContentAt(
+                        Selection.atEnd(typistEditorRef.current?.getEditor().state.doc),
+                        MARKDOWN_PLACEHOLDER_SHORT,
+                    )
                     .run()
             }, [])
 
@@ -64,6 +77,12 @@ export const Commands: StoryObj<typeof TypistEditor> = {
                                     onClick={handleInsertMarkdownContentClick}
                                 >
                                     insertMarkdownContent
+                                </Button>
+                                <Button
+                                    variant="secondary"
+                                    onClick={handleInsertMarkdownContentAtClick}
+                                >
+                                    insertMarkdownContentAt
                                 </Button>
                             </>
                         )


### PR DESCRIPTION
## Overview

This PR introduces the `insertMarkdownContentAt` command, which does the same as the `insertMarkdownContent` that we already have but allows one to pick the insertion position in the document. With the introduction of this command, `insertMarkdownContent` was changed to use `insertMarkdownContentAt`, and use the same API as the matching pair `insertContent`/`insertContentAt` from Tiptap, which the `insertMarkdown*` commands draw inspiration from.

Although the API for `insertMarkdownContent` changed - thus making this a breaking change - it doesn't affect our products because we are not using the part of the API that actually changed (the second parameter). But since it's technically a breaking change, it is being marked as such.

As mentioned above, the `insertMarkdown*` commands are inspired by the `insertContent*` commands from Tiptap, and do pretty much the same things in the same way, but adapted to insert Markdown instead of plain-text or HTML.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Functions → Commands` story
- Press the `insertMarkdownContent` button
    - [x] Observe that the content is inserted successfully
- Place the text cursor in different positions (at the start of the document, middle, middle of a sentence/word, end, etc.), and press the `inserMarkdownContent` button
    - [x] Observe that the content is always inserted exactly at the text cursor position
- Place the text cursor in different positions (at the start of the document, middle, middle of a sentence/word, end, etc.), and press the `inserMarkdownContentAt` button
    - [x] Observe that the content is always inserted exactly at the end of the document (this is how the Storybook demo is configured, but this command allows the insertion position to be picked at runtime)