### PR TITLE
fix: Update ProseMirror imports to `@tiptap/pm/*` packages

### DIFF
--- a/src/components/typist-editor.helper.ts
+++ b/src/components/typist-editor.helper.ts
@@ -1,7 +1,7 @@
+import { Selection, TextSelection } from '@tiptap/pm/state'
 import { clamp } from 'lodash-es'
-import { Selection, TextSelection } from 'prosemirror-state'
 
-import type { Node as ProseMirrorNode } from 'prosemirror-model'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 
 /**
  * Given a ProseMirror document, and a selection, resolves that selection within the bounds of the

--- a/src/components/typist-editor.tsx
+++ b/src/components/typist-editor.tsx
@@ -14,7 +14,7 @@ import { getMarkdownSerializerInstance } from '../serializers/markdown/markdown'
 import { getAllNodesAttributesByType, resolveContentSelection } from './typist-editor.helper'
 
 import type { Editor as CoreEditor, EditorEvents, Extensions } from '@tiptap/core'
-import type { Plugin, Selection } from 'prosemirror-state'
+import type { Plugin, Selection } from '@tiptap/pm/state'
 
 /**
  * The forwarded ref that describes the helper methods that the `TypistEditor` parent component

--- a/src/extensions/core/extra-editor-commands/commands/extend-word-range.ts
+++ b/src/extensions/core/extra-editor-commands/commands/extend-word-range.ts
@@ -1,6 +1,6 @@
 import { isActive, isTextSelection, RawCommands } from '@tiptap/core'
+import { TextSelection } from '@tiptap/pm/state'
 import { clamp } from 'lodash-es'
-import { TextSelection } from 'prosemirror-state'
 
 /**
  * Augment the official `@tiptap/core` module with extra commands so that the compiler knows about

--- a/src/extensions/core/extra-editor-commands/commands/insert-markdown-content.ts
+++ b/src/extensions/core/extra-editor-commands/commands/insert-markdown-content.ts
@@ -1,6 +1,6 @@
 import { RawCommands } from '@tiptap/core'
 
-import type { ParseOptions } from 'prosemirror-model'
+import type { ParseOptions } from '@tiptap/pm/model'
 
 /**
  * Augment the official `@tiptap/core` module with extra commands so that the compiler knows about

--- a/src/extensions/core/view-event-handlers.ts
+++ b/src/extensions/core/view-event-handlers.ts
@@ -1,9 +1,9 @@
 import { Extension } from '@tiptap/core'
-import { Plugin, PluginKey } from 'prosemirror-state'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
 
 import { VIEW_EVENT_HANDLERS_PRIORITY } from '../../constants/extension-priorities'
 
-import type { EditorView } from 'prosemirror-view'
+import type { EditorView } from '@tiptap/pm/view'
 
 /**
  * The options available to customize the `ViewEventHandlers` extension.

--- a/src/extensions/plain-text/paste-multiline-text.ts
+++ b/src/extensions/plain-text/paste-multiline-text.ts
@@ -1,14 +1,14 @@
 /* eslint-disable no-console */
 
 import { Extension } from '@tiptap/core'
-import { Fragment, Slice } from 'prosemirror-model'
-import { Plugin, PluginKey } from 'prosemirror-state'
+import { Fragment, Slice } from '@tiptap/pm/model'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
 
 import { ClipboardDataType } from '../../constants/common'
 import { REGEX_LINE_BREAKS } from '../../constants/regular-expressions'
 
-import type { Schema } from 'prosemirror-model'
-import type { EditorView } from 'prosemirror-view'
+import type { Schema } from '@tiptap/pm/model'
+import type { EditorView } from '@tiptap/pm/view'
 
 /**
  * Handles a text input or paste event, and replaces all found line breaks with paragraph nodes.

--- a/src/extensions/plain-text/smart-markdown-typing/plugins/smart-lists.ts
+++ b/src/extensions/plain-text/smart-markdown-typing/plugins/smart-lists.ts
@@ -1,9 +1,9 @@
-import { Plugin, PluginKey } from 'prosemirror-state'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
 
 import { isMultilineDocument } from '../../../../helpers/schema'
 
-import type { Schema } from 'prosemirror-model'
-import type { EditorView } from 'prosemirror-view'
+import type { Schema } from '@tiptap/pm/model'
+import type { EditorView } from '@tiptap/pm/view'
 
 /**
  * A list of the allowed keys that might trigger smart typing.

--- a/src/extensions/plain-text/smart-markdown-typing/plugins/smart-select-wrap.ts
+++ b/src/extensions/plain-text/smart-markdown-typing/plugins/smart-select-wrap.ts
@@ -1,6 +1,6 @@
-import { Plugin, PluginKey, TextSelection } from 'prosemirror-state'
+import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state'
 
-import type { EditorView } from 'prosemirror-view'
+import type { EditorView } from '@tiptap/pm/view'
 
 /**
  * An object holding the acceptable wrapping symbols. The key represents the trigger character, and

--- a/src/extensions/plain-text/smart-markdown-typing/plugins/smart-url-pasting.ts
+++ b/src/extensions/plain-text/smart-markdown-typing/plugins/smart-url-pasting.ts
@@ -1,8 +1,8 @@
-import { Plugin, PluginKey, TextSelection } from 'prosemirror-state'
+import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state'
 
 import { ClipboardDataType } from '../../../../constants/common'
 
-import type { EditorView } from 'prosemirror-view'
+import type { EditorView } from '@tiptap/pm/view'
 
 /**
  * The perfect URL validation regex for Web URLs.

--- a/src/extensions/rich-text/paste-emojis.ts
+++ b/src/extensions/rich-text/paste-emojis.ts
@@ -1,6 +1,6 @@
 import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
 import emojiRegex from 'emoji-regex'
-import { Plugin, PluginKey } from 'prosemirror-state'
 
 // Regular expression to match all emoji symbols and sequences (including textual representations)
 const baseEmojiRegExp = emojiRegex()

--- a/src/extensions/rich-text/paste-markdown.ts
+++ b/src/extensions/rich-text/paste-markdown.ts
@@ -1,7 +1,7 @@
 import { Extension } from '@tiptap/core'
+import { Fragment, Slice } from '@tiptap/pm/model'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
 import * as linkify from 'linkifyjs'
-import { Fragment, Slice } from 'prosemirror-model'
-import { Plugin, PluginKey } from 'prosemirror-state'
 
 import { ClipboardDataType } from '../../constants/common'
 import { PASTE_MARKDOWN_EXTENSION_PRIORITY } from '../../constants/extension-priorities'

--- a/src/extensions/rich-text/rich-text-image.ts
+++ b/src/extensions/rich-text/rich-text-image.ts
@@ -1,6 +1,6 @@
 import { Image } from '@tiptap/extension-image'
+import { Plugin, PluginKey, Selection } from '@tiptap/pm/state'
 import { ReactNodeViewRenderer } from '@tiptap/react'
-import { Plugin, PluginKey, Selection } from 'prosemirror-state'
 
 import type { NodeViewProps } from '@tiptap/react'
 

--- a/src/extensions/shared/paste-html-table-as-string.ts
+++ b/src/extensions/shared/paste-html-table-as-string.ts
@@ -1,5 +1,5 @@
 import { Extension } from '@tiptap/core'
-import { Plugin, PluginKey } from 'prosemirror-state'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
 
 import { PASTE_HTML_TABLE_AS_STRING_EXTENSION_PRIORITY } from '../../constants/extension-priorities'
 import { parseHtmlToElement } from '../../helpers/dom'

--- a/src/extensions/shared/paste-singleline-text.ts
+++ b/src/extensions/shared/paste-singleline-text.ts
@@ -1,6 +1,6 @@
 import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { escape } from 'lodash-es'
-import { Plugin, PluginKey } from 'prosemirror-state'
 
 import { REGEX_LINE_BREAKS } from '../../constants/regular-expressions'
 import { parseHtmlToElement } from '../../helpers/dom'

--- a/src/factories/create-suggestion-extension.ts
+++ b/src/factories/create-suggestion-extension.ts
@@ -1,7 +1,7 @@
 import { mergeAttributes, Node } from '@tiptap/core'
+import { PluginKey } from '@tiptap/pm/state'
 import { Suggestion as TiptapSuggestion } from '@tiptap/suggestion'
 import { camelCase, kebabCase } from 'lodash-es'
-import { PluginKey } from 'prosemirror-state'
 
 import { SUGGESTION_EXTENSION_PRIORITY } from '../constants/extension-priorities'
 import { canInsertNodeAt } from '../utilities/can-insert-node-at'

--- a/src/helpers/schema.ts
+++ b/src/helpers/schema.ts
@@ -1,4 +1,4 @@
-import type { Schema } from 'prosemirror-model'
+import type { Schema } from '@tiptap/pm/model'
 
 /**
  * Check if the document schema accepts multiple lines of input.

--- a/src/helpers/serializer.ts
+++ b/src/helpers/serializer.ts
@@ -1,6 +1,6 @@
 import { kebabCase } from 'lodash-es'
 
-import type { ParseRule, Schema } from 'prosemirror-model'
+import type { ParseRule, Schema } from '@tiptap/pm/model'
 
 /**
  * Builds a partial regular expression that includes valid URL schemas used by all the available

--- a/src/serializers/html/html.ts
+++ b/src/serializers/html/html.ts
@@ -16,7 +16,7 @@ import { remarkAutolinkLiteral } from './plugins/remark-autolink-literal'
 import { remarkDisableConstructs } from './plugins/remark-disable-constructs'
 import { remarkStrikethrough } from './plugins/remark-strikethrough'
 
-import type { Schema } from 'prosemirror-model'
+import type { Schema } from '@tiptap/pm/model'
 
 /**
  * The return type for the `createHTMLSerializer` function.

--- a/src/serializers/html/plugins/rehype-image.ts
+++ b/src/serializers/html/plugins/rehype-image.ts
@@ -2,7 +2,7 @@ import { isElement } from 'hast-util-is-element'
 import { remove } from 'unist-util-remove'
 import { visit } from 'unist-util-visit'
 
-import type { Schema } from 'prosemirror-model'
+import type { Schema } from '@tiptap/pm/model'
 import type { Transformer } from 'unified'
 import type { Node, Parent } from 'unist'
 

--- a/src/serializers/html/plugins/rehype-suggestions.ts
+++ b/src/serializers/html/plugins/rehype-suggestions.ts
@@ -4,8 +4,8 @@ import { visit } from 'unist-util-visit'
 import { buildSuggestionSchemaPartialRegex } from '../../../helpers/serializer'
 import { isTextNode } from '../../../helpers/unified'
 
+import type { Schema } from '@tiptap/pm/model'
 import type { Node } from 'hast'
-import type { Schema } from 'prosemirror-model'
 import type { Transformer } from 'unified'
 
 /**

--- a/src/serializers/html/plugins/remark-disable-constructs.ts
+++ b/src/serializers/html/plugins/remark-disable-constructs.ts
@@ -1,4 +1,4 @@
-import type { Schema } from 'prosemirror-model'
+import type { Schema } from '@tiptap/pm/model'
 import type { Processor } from 'unified'
 
 /**

--- a/src/serializers/markdown/markdown.ts
+++ b/src/serializers/markdown/markdown.ts
@@ -10,7 +10,7 @@ import { strikethrough } from './plugins/strikethrough'
 import { suggestion } from './plugins/suggestion'
 import { taskItem } from './plugins/task-item'
 
-import type { Schema } from 'prosemirror-model'
+import type { Schema } from '@tiptap/pm/model'
 
 /**
  * The return type for the `createMarkdownSerializer` function.

--- a/src/serializers/markdown/plugins/image.ts
+++ b/src/serializers/markdown/plugins/image.ts
@@ -1,4 +1,4 @@
-import type { NodeType } from 'prosemirror-model'
+import type { NodeType } from '@tiptap/pm/model'
 import type Turndown from 'turndown'
 
 /**

--- a/src/serializers/markdown/plugins/list-item.ts
+++ b/src/serializers/markdown/plugins/list-item.ts
@@ -1,7 +1,7 @@
 import { extractTagsFromParseRules } from '../../../helpers/serializer'
 import { BULLET_LIST_MARKER } from '../markdown'
 
-import type { NodeType } from 'prosemirror-model'
+import type { NodeType } from '@tiptap/pm/model'
 import type Turndown from 'turndown'
 
 /**

--- a/src/serializers/markdown/plugins/paragraph.ts
+++ b/src/serializers/markdown/plugins/paragraph.ts
@@ -1,4 +1,4 @@
-import type { NodeType } from 'prosemirror-model'
+import type { NodeType } from '@tiptap/pm/model'
 import type Turndown from 'turndown'
 
 /**

--- a/src/serializers/markdown/plugins/strikethrough.ts
+++ b/src/serializers/markdown/plugins/strikethrough.ts
@@ -1,6 +1,6 @@
 import { extractTagsFromParseRules } from '../../../helpers/serializer'
 
-import type { MarkType } from 'prosemirror-model'
+import type { MarkType } from '@tiptap/pm/model'
 import type Turndown from 'turndown'
 
 /**

--- a/src/serializers/markdown/plugins/suggestion.ts
+++ b/src/serializers/markdown/plugins/suggestion.ts
@@ -1,6 +1,6 @@
 import { kebabCase } from 'lodash-es'
 
-import type { NodeType } from 'prosemirror-model'
+import type { NodeType } from '@tiptap/pm/model'
 import type Turndown from 'turndown'
 
 /**

--- a/src/serializers/markdown/plugins/task-item.ts
+++ b/src/serializers/markdown/plugins/task-item.ts
@@ -1,7 +1,7 @@
 import { extractTagsFromParseRules } from '../../../helpers/serializer'
 import { BULLET_LIST_MARKER } from '../markdown'
 
-import type { NodeType } from 'prosemirror-model'
+import type { NodeType } from '@tiptap/pm/model'
 import type Turndown from 'turndown'
 
 /**


### PR DESCRIPTION
## Overview

To avoid conflicts between different dependencies versions, and to make sure that we are always use the same `prosemirror-*` dependencies as Tiptap, all imports have been changed to `@tiptap/pm/*`. This is long overdue, and something I simply forgot to do.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

As long as it builds, everything should be fine.