### PR TITLE
chore: Update actions to support NodeJS 20

### DIFF
--- a/.github/workflows/check-ci-validation.yml
+++ b/.github/workflows/check-ci-validation.yml
@@ -24,7 +24,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Prepare Node.js environment
               uses: actions/setup-node@v3
@@ -54,7 +54,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Prepare Node.js environment
               uses: actions/setup-node@v3
@@ -96,7 +96,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Prepare Node.js environment
               uses: actions/setup-node@v3
@@ -130,7 +130,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Prepare Node.js environment
               uses: actions/setup-node@v3

--- a/.github/workflows/publish-typist-package-release.yml
+++ b/.github/workflows/publish-typist-package-release.yml
@@ -38,7 +38,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   token: ${{ secrets.GH_REPO_TOKEN }}
 

--- a/.github/workflows/update-license-copyright-year.yml
+++ b/.github/workflows/update-license-copyright-year.yml
@@ -12,7 +12,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   token: ${{ secrets.GH_REPO_TOKEN }}
 


### PR DESCRIPTION
This PR updates the actions to versions that no longer rely on NodeJS 16, which has reached its end of life. By upgrading the actions, we ensure compatibility with the latest NodeJS 20 runtime.

For https://github.com/Doist/infrastructure-backlog/issues/628
