### PR TITLE
feat: add support for Node v20 and npm v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
             "devDependencies": {
                 "@doist/eslint-config": "11.0.0",
                 "@doist/prettier-config": "4.0.0",
-                "@doist/reactist": "21.3.0",
+                "@doist/reactist": "22.1.0",
                 "@mdx-js/react": "2.3.0",
                 "@semantic-release/changelog": "6.0.3",
                 "@semantic-release/exec": "6.0.3",
@@ -100,8 +100,8 @@
                 "vitest": "0.34.5"
             },
             "engines": {
-                "node": "^16.0.0 || ^18.0.0",
-                "npm": "^7.0.0 || ^8.0.0 || ^9.0.0"
+                "node": "^16.0.0 || ^18.0.0 || ^20.0.0",
+                "npm": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
             },
             "peerDependencies": {
                 "@react-hookz/web": "^14.2.3 || >=15.x",
@@ -2257,13 +2257,12 @@
             }
         },
         "node_modules/@doist/reactist": {
-            "version": "21.3.0",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-21.3.0.tgz",
-            "integrity": "sha512-dxgeNyhO6x9cbfv/pMhUmCRrTjY9ITpNtGJyG1diX6Ze7fyROuX8/L0f3H5jQtcahZRTXLG99IrPSZN6PamuYg==",
+            "version": "22.1.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-22.1.0.tgz",
+            "integrity": "sha512-o4N9oxQiuk6bUhlaKNwAOTWHBS6WCtXMHOp3DXJp3sMyFr80ydQsMb5gs4lNflspD2OhdlVsK5oIYJ8j00d74A==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "@reach/dialog": "^0.16.0",
                 "aria-hidden": "^1.2.1",
                 "ariakit": "2.0.0-next.43",
                 "ariakit-react-utils": "0.17.0-next.27",
@@ -2276,61 +2275,14 @@
                 "use-callback-ref": "^1.3.0"
             },
             "engines": {
-                "node": "^16.0.0 || ^18.0.0",
-                "npm": "^8.3.0 || ^9.0.0"
+                "node": "^16.0.0 || ^18.0.0 || ^20.0.0",
+                "npm": "^8.3.0 || ^9.0.0 || ^10.0.0"
             },
             "peerDependencies": {
                 "classnames": "^2.2.5",
                 "prop-types": "^15.6.2",
                 "react": "^17.0.0 || ^18.0.0",
                 "react-dom": "^17.0.0 || ^18.0.0"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/@reach/dialog": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/@reach/dialog/-/dialog-0.16.2.tgz",
-            "integrity": "sha512-qq8oX0cROgTb8LjOKWzzNm4SqaN9b89lJHr7UyVo2aQ6WbeNzZBxqXhGywFP7dkR+hNqOJnrA59PXFWhfttA9A==",
-            "dev": true,
-            "dependencies": {
-                "@reach/portal": "0.16.2",
-                "@reach/utils": "0.16.0",
-                "prop-types": "^15.7.2",
-                "react-focus-lock": "^2.5.2",
-                "react-remove-scroll": "^2.4.3",
-                "tslib": "^2.3.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || 17.x",
-                "react-dom": "^16.8.0 || 17.x"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/@reach/dialog/node_modules/@reach/portal": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.2.tgz",
-            "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
-            "dev": true,
-            "dependencies": {
-                "@reach/utils": "0.16.0",
-                "tiny-warning": "^1.0.3",
-                "tslib": "^2.3.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || 17.x",
-                "react-dom": "^16.8.0 || 17.x"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/@reach/dialog/node_modules/@reach/utils": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-            "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-            "dev": true,
-            "dependencies": {
-                "tiny-warning": "^1.0.3",
-                "tslib": "^2.3.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || 17.x",
-                "react-dom": "^16.8.0 || 17.x"
             }
         },
         "node_modules/@doist/reactist/node_modules/bail": {
@@ -10242,6 +10194,7 @@
             "version": "2.0.0-next.43",
             "resolved": "https://registry.npmjs.org/ariakit/-/ariakit-2.0.0-next.43.tgz",
             "integrity": "sha512-CatNgIMyurefYTEvp8aF3aQQGR5m9bZxYQXuqyw/MKwxJ/aJ295SSSY5pXyTHbbsgDI28GOKFYa5pfUBvkd7cQ==",
+            "deprecated": "The ariakit package has been renamed to @ariakit/react. Visit https://ariakit.org for more info.",
             "dev": true,
             "dependencies": {
                 "@floating-ui/dom": "^1.0.0",
@@ -11874,9 +11827,9 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.7",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-            "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
+            "version": "1.11.10",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+            "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
             "dev": true
         },
         "node_modules/debug": {
@@ -12294,14 +12247,14 @@
             "peer": true
         },
         "node_modules/domutils": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+            "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
             "dev": true,
             "dependencies": {
                 "dom-serializer": "^2.0.0",
                 "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.1"
+                "domhandler": "^5.0.3"
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -15367,14 +15320,17 @@
             }
         },
         "node_modules/html-to-react": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.5.0.tgz",
-            "integrity": "sha512-tjihXBgaJZRRYzmkrJZ/Qf9jFayilFYcb+sJxXXE2BVLk2XsNrGeuNCVvhXmvREULZb9dz6NFTBC96DTR/lQCQ==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.6.0.tgz",
+            "integrity": "sha512-W7HvCu2fipgz3F7fpEtIt2Ty6XcqFGQXOorR4+HQAk72y9mTtUH3BmJ43BEvXQHO+bt//z1Hbfe6JzojpSC/9w==",
             "dev": true,
             "dependencies": {
                 "domhandler": "^5.0",
                 "htmlparser2": "^8.0",
                 "lodash.camelcase": "^4.3.0"
+            },
+            "peerDependencies": {
+                "react": "^0.13.0 || ^0.14.0 || >=15"
             }
         },
         "node_modules/html-void-elements": {
@@ -15388,9 +15344,9 @@
             }
         },
         "node_modules/htmlparser2": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-            "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+            "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
             "dev": true,
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -15401,9 +15357,9 @@
             ],
             "dependencies": {
                 "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
+                "domhandler": "^5.0.3",
                 "domutils": "^3.0.1",
-                "entities": "^4.3.0"
+                "entities": "^4.4.0"
             }
         },
         "node_modules/http-errors": {
@@ -24945,9 +24901,9 @@
             "dev": true
         },
         "node_modules/react-focus-lock": {
-            "version": "2.9.4",
-            "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-            "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+            "version": "2.9.5",
+            "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
+            "integrity": "sha512-h6vrdgUbsH2HeD5I7I3Cx1PPrmwGuKYICS+kB9m+32X/9xHRrAbxgvaBpG7BFBN9h3tO+C3qX1QAVESmi4CiIA==",
             "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.0.0",
@@ -27851,12 +27807,6 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
             "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
-            "dev": true
-        },
-        "node_modules/tiny-warning": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
             "dev": true
         },
         "node_modules/tinybench": {
@@ -31032,12 +30982,11 @@
             "requires": {}
         },
         "@doist/reactist": {
-            "version": "21.3.0",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-21.3.0.tgz",
-            "integrity": "sha512-dxgeNyhO6x9cbfv/pMhUmCRrTjY9ITpNtGJyG1diX6Ze7fyROuX8/L0f3H5jQtcahZRTXLG99IrPSZN6PamuYg==",
+            "version": "22.1.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-22.1.0.tgz",
+            "integrity": "sha512-o4N9oxQiuk6bUhlaKNwAOTWHBS6WCtXMHOp3DXJp3sMyFr80ydQsMb5gs4lNflspD2OhdlVsK5oIYJ8j00d74A==",
             "dev": true,
             "requires": {
-                "@reach/dialog": "^0.16.0",
                 "aria-hidden": "^1.2.1",
                 "ariakit": "2.0.0-next.43",
                 "ariakit-react-utils": "0.17.0-next.27",
@@ -31050,43 +30999,6 @@
                 "use-callback-ref": "^1.3.0"
             },
             "dependencies": {
-                "@reach/dialog": {
-                    "version": "0.16.2",
-                    "resolved": "https://registry.npmjs.org/@reach/dialog/-/dialog-0.16.2.tgz",
-                    "integrity": "sha512-qq8oX0cROgTb8LjOKWzzNm4SqaN9b89lJHr7UyVo2aQ6WbeNzZBxqXhGywFP7dkR+hNqOJnrA59PXFWhfttA9A==",
-                    "dev": true,
-                    "requires": {
-                        "@reach/portal": "0.16.2",
-                        "@reach/utils": "0.16.0",
-                        "prop-types": "^15.7.2",
-                        "react-focus-lock": "^2.5.2",
-                        "react-remove-scroll": "^2.4.3",
-                        "tslib": "^2.3.0"
-                    },
-                    "dependencies": {
-                        "@reach/portal": {
-                            "version": "0.16.2",
-                            "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.2.tgz",
-                            "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
-                            "dev": true,
-                            "requires": {
-                                "@reach/utils": "0.16.0",
-                                "tiny-warning": "^1.0.3",
-                                "tslib": "^2.3.0"
-                            }
-                        },
-                        "@reach/utils": {
-                            "version": "0.16.0",
-                            "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-                            "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-                            "dev": true,
-                            "requires": {
-                                "tiny-warning": "^1.0.3",
-                                "tslib": "^2.3.0"
-                            }
-                        }
-                    }
-                },
                 "bail": {
                     "version": "1.0.5",
                     "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
@@ -37546,9 +37458,9 @@
             }
         },
         "dayjs": {
-            "version": "1.11.7",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-            "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
+            "version": "1.11.10",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+            "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
             "dev": true
         },
         "debug": {
@@ -37853,14 +37765,14 @@
             "peer": true
         },
         "domutils": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+            "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
             "dev": true,
             "requires": {
                 "dom-serializer": "^2.0.0",
                 "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.1"
+                "domhandler": "^5.0.3"
             }
         },
         "dot-prop": {
@@ -40184,9 +40096,9 @@
             "dev": true
         },
         "html-to-react": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.5.0.tgz",
-            "integrity": "sha512-tjihXBgaJZRRYzmkrJZ/Qf9jFayilFYcb+sJxXXE2BVLk2XsNrGeuNCVvhXmvREULZb9dz6NFTBC96DTR/lQCQ==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.6.0.tgz",
+            "integrity": "sha512-W7HvCu2fipgz3F7fpEtIt2Ty6XcqFGQXOorR4+HQAk72y9mTtUH3BmJ43BEvXQHO+bt//z1Hbfe6JzojpSC/9w==",
             "dev": true,
             "requires": {
                 "domhandler": "^5.0",
@@ -40201,15 +40113,15 @@
             "peer": true
         },
         "htmlparser2": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-            "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+            "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
             "dev": true,
             "requires": {
                 "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
+                "domhandler": "^5.0.3",
                 "domutils": "^3.0.1",
-                "entities": "^4.3.0"
+                "entities": "^4.4.0"
             }
         },
         "http-errors": {
@@ -46878,9 +46790,9 @@
             }
         },
         "react-focus-lock": {
-            "version": "2.9.4",
-            "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-            "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+            "version": "2.9.5",
+            "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
+            "integrity": "sha512-h6vrdgUbsH2HeD5I7I3Cx1PPrmwGuKYICS+kB9m+32X/9xHRrAbxgvaBpG7BFBN9h3tO+C3qX1QAVESmi4CiIA==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.0.0",
@@ -49049,12 +48961,6 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
             "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
-            "dev": true
-        },
-        "tiny-warning": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
             "dev": true
         },
         "tinybench": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "types": "dist/index.d.ts",
     "sideEffects": false,
     "engines": {
-        "node": "^16.0.0 || ^18.0.0",
-        "npm": "^7.0.0 || ^8.0.0 || ^9.0.0"
+        "node": "^16.0.0 || ^18.0.0 || ^20.0.0",
+        "npm": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
     },
     "publishConfig": {
         "access": "public"
@@ -81,7 +81,7 @@
     "devDependencies": {
         "@doist/eslint-config": "11.0.0",
         "@doist/prettier-config": "4.0.0",
-        "@doist/reactist": "21.3.0",
+        "@doist/reactist": "22.1.0",
         "@mdx-js/react": "2.3.0",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/exec": "6.0.3",


### PR DESCRIPTION
<!-- Thank you for your contribution to the Typist repository. -->

<!-- Please remove all sections that are not relevant. -->

## Overview

<!-- Please include a summary of the changes and the related issue. -->
<!-- Please also include relevant motivation and context. -->

Adds support for Node v20 and npm v10 to the `engines` field on `package.json`.

`@doist/reactist` is also bumped to the last version, which introduced the same Node/npm support.

This change could have been prefixed with "chore", but we're considering it a feature (added support) to trigger a minor release update.

## PR Checklist

<!-- Feel free to remove the lines that are not applicable or leave them unchecked. -->

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
