### PR TITLE
feat: add support for Node v21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
             "devDependencies": {
                 "@doist/eslint-config": "11.0.0",
                 "@doist/prettier-config": "4.0.0",
-                "@doist/reactist": "22.2.0",
+                "@doist/reactist": "22.3.0",
                 "@mdx-js/react": "2.3.0",
                 "@semantic-release/changelog": "6.0.3",
                 "@semantic-release/exec": "6.0.3",
@@ -100,7 +100,7 @@
                 "vitest": "0.34.6"
             },
             "engines": {
-                "node": "^16.0.0 || ^18.0.0 || ^20.0.0",
+                "node": "^16.0.0 || ^18.0.0 || ^20.0.0 || ^21.0.0",
                 "npm": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
             },
             "peerDependencies": {
@@ -2267,9 +2267,9 @@
             }
         },
         "node_modules/@doist/reactist": {
-            "version": "22.2.0",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-22.2.0.tgz",
-            "integrity": "sha512-CKlzbpcitrCLI5IWdZEhHbQi2Hsui/HElc2+tIKy/dXj7Xy+86hKp6zAqIiGbNSfZh8DWlNdwttLoCCQyOtekw==",
+            "version": "22.3.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-22.3.0.tgz",
+            "integrity": "sha512-03BOHsvOIedbNyTFga2QfQami5+10OzA2t6qlkaqjuy0tWKawd7GC/6X3KsIb4GstyRcOEfqIdp9np1EYYJoHA==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -2285,7 +2285,7 @@
                 "use-callback-ref": "^1.3.0"
             },
             "engines": {
-                "node": "^16.0.0 || ^18.0.0 || ^20.0.0",
+                "node": "^16.0.0 || ^18.0.0 || ^20.0.0 || ^21.0.0",
                 "npm": "^8.3.0 || ^9.0.0 || ^10.0.0"
             },
             "peerDependencies": {
@@ -30712,9 +30712,9 @@
             "requires": {}
         },
         "@doist/reactist": {
-            "version": "22.2.0",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-22.2.0.tgz",
-            "integrity": "sha512-CKlzbpcitrCLI5IWdZEhHbQi2Hsui/HElc2+tIKy/dXj7Xy+86hKp6zAqIiGbNSfZh8DWlNdwttLoCCQyOtekw==",
+            "version": "22.3.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-22.3.0.tgz",
+            "integrity": "sha512-03BOHsvOIedbNyTFga2QfQami5+10OzA2t6qlkaqjuy0tWKawd7GC/6X3KsIb4GstyRcOEfqIdp9np1EYYJoHA==",
             "dev": true,
             "requires": {
                 "aria-hidden": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "types": "dist/index.d.ts",
     "sideEffects": false,
     "engines": {
-        "node": "^16.0.0 || ^18.0.0 || ^20.0.0",
+        "node": "^16.0.0 || ^18.0.0 || ^20.0.0 || ^21.0.0",
         "npm": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
     },
     "publishConfig": {
@@ -81,7 +81,7 @@
     "devDependencies": {
         "@doist/eslint-config": "11.0.0",
         "@doist/prettier-config": "4.0.0",
-        "@doist/reactist": "22.2.0",
+        "@doist/reactist": "22.3.0",
         "@mdx-js/react": "2.3.0",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/exec": "6.0.3",


### PR DESCRIPTION
<!-- Thank you for your contribution to the Typist repository. -->

<!-- Please remove all sections that are not relevant. -->

## Overview

<!-- Please include a summary of the changes and the related issue. -->
<!-- Please also include relevant motivation and context. -->

Adds support for Node v21 to the `engines` field on `package.json`.

`@doist/reactist` is also bumped to the last version, which introduced the same Node/npm support.

This change could have been prefixed with "chore", but we're considering it a feature (added support) to trigger a minor release update.

## PR Checklist

<!-- Feel free to remove the lines that are not applicable or leave them unchecked. -->

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
