### PR TITLE
feat(commands): Add `smartToggleBulletList` and `smartToggleOrderedList`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
                 "@tiptap/extension-task-item": "2.1.13",
                 "@tiptap/extension-task-list": "2.1.13",
                 "@tiptap/extension-text": "2.1.13",
+                "@tiptap/extension-text-style": "2.1.13",
                 "@tiptap/extension-typography": "2.1.13",
                 "@tiptap/pm": "2.1.13",
                 "@tiptap/react": "2.1.13",
@@ -7067,6 +7068,18 @@
             "version": "2.1.13",
             "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.1.13.tgz",
             "integrity": "sha512-zzsTTvu5U67a8WjImi6DrmpX2Q/onLSaj+LRWPh36A1Pz2WaxW5asZgaS+xWCnR+UrozlCALWa01r7uv69jq0w==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/ueberdosis"
+            },
+            "peerDependencies": {
+                "@tiptap/core": "^2.0.0"
+            }
+        },
+        "node_modules/@tiptap/extension-text-style": {
+            "version": "2.1.13",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.1.13.tgz",
+            "integrity": "sha512-K9/pNHxpZKQoc++crxrsppVUSeHv8YevfY2FkJ4YMaekGcX+q4BRrHR0tOfii4izAUPJF2L0/PexLQaWXtAY1w==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "@tiptap/extension-task-item": "2.1.13",
         "@tiptap/extension-task-list": "2.1.13",
         "@tiptap/extension-text": "2.1.13",
+        "@tiptap/extension-text-style": "2.1.13",
         "@tiptap/extension-typography": "2.1.13",
         "@tiptap/pm": "2.1.13",
         "@tiptap/react": "2.1.13",

--- a/src/extensions/rich-text/rich-text-bullet-list.ts
+++ b/src/extensions/rich-text/rich-text-bullet-list.ts
@@ -1,0 +1,87 @@
+import { BulletList } from '@tiptap/extension-bullet-list'
+import { ListItem } from '@tiptap/extension-list-item'
+import { TextStyle } from '@tiptap/extension-text-style'
+import { Fragment, Slice } from '@tiptap/pm/model'
+
+import type { BulletListOptions } from '@tiptap/extension-bullet-list'
+
+/**
+ * Augment the official `@tiptap/core` module with extra commands, relevant for this extension, so
+ * that the compiler knows about them.
+ */
+declare module '@tiptap/core' {
+    interface Commands<ReturnType> {
+        richTextBulletList: {
+            /**
+             * Smartly toggles the selection into a bullet list, converting any hard breaks into
+             * paragraphs before doing so.
+             *
+             * @see https://discuss.prosemirror.net/t/how-to-convert-a-selection-of-text-lines-into-paragraphs/6099
+             */
+            smartToggleBulletList: () => ReturnType
+        }
+    }
+}
+
+/**
+ * Custom extension that extends the built-in `BulletList` extension to add a smart toggle command
+ * with support for hard breaks, which are automatically converted into paragraphs before toggling
+ * the selection into a bullet list.
+ */
+const RichTextBulletList = BulletList.extend({
+    addCommands() {
+        const { editor, name, options } = this
+
+        return {
+            smartToggleBulletList() {
+                return ({ commands, state, tr, chain }) => {
+                    const { schema } = state
+                    const { selection } = tr
+                    const { $from, $to } = selection
+
+                    const hardBreakPositions: number[] = []
+
+                    // Find and store the positions of all hard breaks in the selection
+                    tr.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
+                        if (node.type.name === 'hardBreak') {
+                            hardBreakPositions.push(pos)
+                        }
+                    })
+
+                    // Replace each hard break with a slice that closes and re-opens a paragraph,
+                    // effectively inserting a "paragraph break" in place of a "hard break"
+                    // (this is performed in reverse order to compensate for content shifting that
+                    // occurs with each replacement, ensuring accurate insertion points)
+                    hardBreakPositions.reverse().forEach((pos) => {
+                        tr.replace(
+                            pos,
+                            pos + 1,
+                            Slice.maxOpen(
+                                Fragment.fromArray([
+                                    schema.nodes.paragraph.create(),
+                                    schema.nodes.paragraph.create(),
+                                ]),
+                            ),
+                        )
+                    })
+
+                    // Toggle the selection into a bullet list, optionally keeping attributes
+                    // (this is a verbatim copy of the built-in`toggleBulletList` command)
+
+                    if (options.keepAttributes) {
+                        return chain()
+                            .toggleList(name, options.itemTypeName, options.keepMarks)
+                            .updateAttributes(ListItem.name, editor.getAttributes(TextStyle.name))
+                            .run()
+                    }
+
+                    return commands.toggleList(name, options.itemTypeName, options.keepMarks)
+                }
+            },
+        }
+    },
+})
+
+export { RichTextBulletList }
+
+export type { BulletListOptions as RichTextBulletListOptions }

--- a/src/extensions/rich-text/rich-text-kit.ts
+++ b/src/extensions/rich-text/rich-text-kit.ts
@@ -1,7 +1,6 @@
 import { Extension } from '@tiptap/core'
 import { Blockquote } from '@tiptap/extension-blockquote'
 import { Bold } from '@tiptap/extension-bold'
-import { BulletList } from '@tiptap/extension-bullet-list'
 import { CodeBlock } from '@tiptap/extension-code-block'
 import { Dropcursor } from '@tiptap/extension-dropcursor'
 import { Gapcursor } from '@tiptap/extension-gapcursor'
@@ -12,7 +11,6 @@ import { HorizontalRule } from '@tiptap/extension-horizontal-rule'
 import { Italic } from '@tiptap/extension-italic'
 import { ListItem } from '@tiptap/extension-list-item'
 import { ListKeymap } from '@tiptap/extension-list-keymap'
-import { OrderedList } from '@tiptap/extension-ordered-list'
 import { Paragraph } from '@tiptap/extension-paragraph'
 import { Text } from '@tiptap/extension-text'
 import { Typography } from '@tiptap/extension-typography'
@@ -26,16 +24,17 @@ import { BoldAndItalics } from './bold-and-italics'
 import { CurvenoteCodemark } from './curvenote-codemark'
 import { PasteEmojis } from './paste-emojis'
 import { PasteMarkdown } from './paste-markdown'
+import { RichTextBulletList } from './rich-text-bullet-list'
 import { RichTextCode } from './rich-text-code'
 import { RichTextDocument } from './rich-text-document'
 import { RichTextImage } from './rich-text-image'
 import { RichTextLink } from './rich-text-link'
-import { RichTextStrikethrough, RichTextStrikethroughOptions } from './rich-text-strikethrough'
+import { RichTextOrderedList } from './rich-text-ordered-list'
+import { RichTextStrikethrough } from './rich-text-strikethrough'
 
 import type { Extensions } from '@tiptap/core'
 import type { BlockquoteOptions } from '@tiptap/extension-blockquote'
 import type { BoldOptions } from '@tiptap/extension-bold'
-import type { BulletListOptions } from '@tiptap/extension-bullet-list'
 import type { CodeOptions } from '@tiptap/extension-code'
 import type { CodeBlockOptions } from '@tiptap/extension-code-block'
 import type { DropcursorOptions } from '@tiptap/extension-dropcursor'
@@ -46,11 +45,13 @@ import type { HorizontalRuleOptions } from '@tiptap/extension-horizontal-rule'
 import type { ItalicOptions } from '@tiptap/extension-italic'
 import type { ListItemOptions } from '@tiptap/extension-list-item'
 import type { ListKeymapOptions } from '@tiptap/extension-list-keymap'
-import type { OrderedListOptions } from '@tiptap/extension-ordered-list'
 import type { ParagraphOptions } from '@tiptap/extension-paragraph'
+import type { RichTextBulletListOptions } from './rich-text-bullet-list'
 import type { RichTextDocumentOptions } from './rich-text-document'
 import type { RichTextImageOptions } from './rich-text-image'
 import type { RichTextLinkOptions } from './rich-text-link'
+import type { RichTextOrderedListOptions } from './rich-text-ordered-list'
+import type { RichTextStrikethroughOptions } from './rich-text-strikethrough'
 
 /**
  * The options available to customize the `RichTextKit` extension.
@@ -69,7 +70,7 @@ type RichTextKitOptions = {
     /**
      * Set options for the `BulletList` extension, or `false` to disable.
      */
-    bulletList: Partial<BulletListOptions> | false
+    bulletList: Partial<RichTextBulletListOptions> | false
 
     /**
      * Set options for the `Code` extension, or `false` to disable.
@@ -144,7 +145,7 @@ type RichTextKitOptions = {
     /**
      * Set options for the `OrderedList` extension, or `false` to disable.
      */
-    orderedList: Partial<OrderedListOptions> | false
+    orderedList: Partial<RichTextOrderedListOptions> | false
 
     /**
      * Set options for the `Paragraph` extension, or `false` to disable.
@@ -210,7 +211,7 @@ const RichTextKit = Extension.create<RichTextKitOptions>({
         }
 
         if (this.options.bulletList !== false) {
-            extensions.push(BulletList.configure(this.options?.bulletList))
+            extensions.push(RichTextBulletList.configure(this.options?.bulletList))
         }
 
         if (this.options.code !== false) {
@@ -310,7 +311,7 @@ const RichTextKit = Extension.create<RichTextKitOptions>({
         }
 
         if (this.options.orderedList !== false) {
-            extensions.push(OrderedList.configure(this.options?.orderedList))
+            extensions.push(RichTextOrderedList.configure(this.options?.orderedList))
         }
 
         if (this.options.paragraph !== false) {

--- a/src/extensions/rich-text/rich-text-ordered-list.ts
+++ b/src/extensions/rich-text/rich-text-ordered-list.ts
@@ -1,0 +1,87 @@
+import { ListItem } from '@tiptap/extension-list-item'
+import { OrderedList } from '@tiptap/extension-ordered-list'
+import { TextStyle } from '@tiptap/extension-text-style'
+import { Fragment, Slice } from '@tiptap/pm/model'
+
+import type { OrderedListOptions } from '@tiptap/extension-ordered-list'
+
+/**
+ * Augment the official `@tiptap/core` module with extra commands, relevant for this extension, so
+ * that the compiler knows about them.
+ */
+declare module '@tiptap/core' {
+    interface Commands<ReturnType> {
+        richTextOrderedList: {
+            /**
+             * Smartly toggles the selection into an oredered list, converting any hard breaks into
+             * paragraphs before doing so.
+             *
+             * @see https://discuss.prosemirror.net/t/how-to-convert-a-selection-of-text-lines-into-paragraphs/6099
+             */
+            smartToggleOrderedList: () => ReturnType
+        }
+    }
+}
+
+/**
+ * Custom extension that extends the built-in `OrderedList` extension to add a smart toggle command
+ * with support for hard breaks, which are automatically converted into paragraphs before toggling
+ * the selection into an ordered list.
+ */
+const RichTextOrderedList = OrderedList.extend({
+    addCommands() {
+        const { editor, name, options } = this
+
+        return {
+            smartToggleOrderedList() {
+                return ({ commands, state, tr, chain }) => {
+                    const { schema } = state
+                    const { selection } = tr
+                    const { $from, $to } = selection
+
+                    const hardBreakPositions: number[] = []
+
+                    // Find and store the positions of all hard breaks in the selection
+                    tr.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
+                        if (node.type.name === 'hardBreak') {
+                            hardBreakPositions.push(pos)
+                        }
+                    })
+
+                    // Replace each hard break with a slice that closes and re-opens a paragraph,
+                    // effectively inserting a "paragraph break" in place of a "hard break"
+                    // (this is performed in reverse order to compensate for content shifting that
+                    // occurs with each replacement, ensuring accurate insertion points)
+                    hardBreakPositions.reverse().forEach((pos) => {
+                        tr.replace(
+                            pos,
+                            pos + 1,
+                            Slice.maxOpen(
+                                Fragment.fromArray([
+                                    schema.nodes.paragraph.create(),
+                                    schema.nodes.paragraph.create(),
+                                ]),
+                            ),
+                        )
+                    })
+
+                    // Toggle the selection into a bullet list, optionally keeping attributes
+                    // (this is a verbatim copy of the built-in`toggleBulletList` command)
+
+                    if (options.keepAttributes) {
+                        return chain()
+                            .toggleList(name, options.itemTypeName, options.keepMarks)
+                            .updateAttributes(ListItem.name, editor.getAttributes(TextStyle.name))
+                            .run()
+                    }
+
+                    return commands.toggleList(name, options.itemTypeName, options.keepMarks)
+                }
+            },
+        }
+    },
+})
+
+export { RichTextOrderedList }
+
+export type { OrderedListOptions as RichTextOrderedListOptions }

--- a/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-toolbar.tsx
+++ b/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-toolbar.tsx
@@ -187,7 +187,7 @@ function TypistEditorToolbar({ editor }: TypistEditorToolbarProps) {
                 disabled={false}
                 icon={<RiListUnordered />}
                 variant="quaternary"
-                onClick={() => editor.chain().focus().toggleBulletList().run()}
+                onClick={() => editor.chain().focus().smartToggleBulletList().run()}
             />
             <Button
                 aria-label="Ordered List"
@@ -195,7 +195,7 @@ function TypistEditorToolbar({ editor }: TypistEditorToolbarProps) {
                 disabled={false}
                 icon={<RiListOrdered />}
                 variant="quaternary"
-                onClick={() => editor.chain().focus().toggleOrderedList().run()}
+                onClick={() => editor.chain().focus().smartToggleOrderedList().run()}
             />
             <Button
                 aria-label="Code Block"


### PR DESCRIPTION
## Overview

This PR adds 2 new toggle functions, one for the `BulletList` extension and another for the `OrderedList` extension, that smartly toggle paragraphs with hard breaks (i.e. newlines) into a bullet/ordered list.

This will help close this internal issue:

- https://github.com/Doist/Issues/issues/7486

## PR Checklist

<!-- Feel free to remove the lines that are not applicable or leave them unchecked. -->

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
-   [x] Added/updated documentation to Storybook or `README.md`

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Write some paragraphs, some with newlines, others without
- Make a selection of those paragraphs (select everything, select them partially, etc.)
- Click the `Bullet List` or `Ordered List` buttons in the editor toolbar
    - [x] Observe that each selected paragraph and/or newline (even partially), is converted into a bullet/ordered list

## Demo

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>

https://github.com/Doist/typist/assets/96476/01328343-51e4-428a-9c78-975231168f54

</td><td>

https://github.com/Doist/typist/assets/96476/4d17398c-0785-499d-a830-63f66b8ebe28

</td></tr>
</tbody>
</table>