### PR TITLE
fix(commands): Restore built-in `toggleBulletList` and `toggleOrderedList`

### DIFF
--- a/src/extensions/rich-text/rich-text-bullet-list.ts
+++ b/src/extensions/rich-text/rich-text-bullet-list.ts
@@ -33,6 +33,7 @@ const RichTextBulletList = BulletList.extend({
         const { editor, name, options } = this
 
         return {
+            ...this.parent?.(),
             smartToggleBulletList() {
                 return ({ commands, state, tr, chain }) => {
                     const { schema } = state

--- a/src/extensions/rich-text/rich-text-ordered-list.ts
+++ b/src/extensions/rich-text/rich-text-ordered-list.ts
@@ -33,6 +33,7 @@ const RichTextOrderedList = OrderedList.extend({
         const { editor, name, options } = this
 
         return {
+            ...this.parent?.(),
             smartToggleOrderedList() {
                 return ({ commands, state, tr, chain }) => {
                     const { schema } = state


### PR DESCRIPTION
## Overview

Fixes an issue introduced by https://github.com/Doist/typist/pull/612 where the built-in `toggleBulletList` and `toggleOrderedList` were removed by mistake. This PR re-introduces them.

## PR Checklist

<!-- Feel free to remove the lines that are not applicable or leave them unchecked. -->

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

It's not possible to test this without changing the code, but if you look at the code and know how Tiptap extensions work, you'll know this change makes sense 😅