### PR TITLE
feat(extensions)!: Overwrite built-in List/Ordered toggle functions with a `smartToggle` option

### DIFF
--- a/src/extensions/rich-text/rich-text-bullet-list.ts
+++ b/src/extensions/rich-text/rich-text-bullet-list.ts
@@ -6,68 +6,71 @@ import { Fragment, Slice } from '@tiptap/pm/model'
 import type { BulletListOptions } from '@tiptap/extension-bullet-list'
 
 /**
- * Augment the official `@tiptap/core` module with extra commands, relevant for this extension, so
- * that the compiler knows about them.
+ * The options available to customize the `RichTextBulletList` extension.
  */
-declare module '@tiptap/core' {
-    interface Commands<ReturnType> {
-        richTextBulletList: {
-            /**
-             * Smartly toggles the selection into a bullet list, converting any hard breaks into
-             * paragraphs before doing so.
-             *
-             * @see https://discuss.prosemirror.net/t/how-to-convert-a-selection-of-text-lines-into-paragraphs/6099
-             */
-            smartToggleBulletList: () => ReturnType
-        }
-    }
-}
+type RichTextBulletListOptions = {
+    /**
+     * Replace hard breaks in the selection with paragraphs before toggling the selection into a
+     * bullet list. By default, hard breaks are not replaced.
+     */
+    smartToggle: boolean
+} & BulletListOptions
 
 /**
- * Custom extension that extends the built-in `BulletList` extension to add a smart toggle command
- * with support for hard breaks, which are automatically converted into paragraphs before toggling
- * the selection into a bullet list.
+ * Custom extension that extends the built-in `BulletList` extension to add an option for smart
+ * toggling, which takes into account hard breaks in the selection, and converts them into
+ * paragraphs before toggling the selection into a bullet list.
  */
-const RichTextBulletList = BulletList.extend({
+const RichTextBulletList = BulletList.extend<RichTextBulletListOptions>({
+    addOptions() {
+        return {
+            ...this.parent?.(),
+            smartToggle: false,
+        }
+    },
+
     addCommands() {
         const { editor, name, options } = this
 
         return {
             ...this.parent?.(),
-            smartToggleBulletList() {
+            toggleBulletList() {
                 return ({ commands, state, tr, chain }) => {
-                    const { schema } = state
-                    const { selection } = tr
-                    const { $from, $to } = selection
+                    // Replace hard breaks in the selection with paragraphs before toggling?
+                    if (options.smartToggle) {
+                        const { schema } = state
+                        const { selection } = tr
+                        const { $from, $to } = selection
 
-                    const hardBreakPositions: number[] = []
+                        const hardBreakPositions: number[] = []
 
-                    // Find and store the positions of all hard breaks in the selection
-                    tr.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
-                        if (node.type.name === 'hardBreak') {
-                            hardBreakPositions.push(pos)
-                        }
-                    })
+                        // Find and store the positions of all hard breaks in the selection
+                        tr.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
+                            if (node.type.name === 'hardBreak') {
+                                hardBreakPositions.push(pos)
+                            }
+                        })
 
-                    // Replace each hard break with a slice that closes and re-opens a paragraph,
-                    // effectively inserting a "paragraph break" in place of a "hard break"
-                    // (this is performed in reverse order to compensate for content shifting that
-                    // occurs with each replacement, ensuring accurate insertion points)
-                    hardBreakPositions.reverse().forEach((pos) => {
-                        tr.replace(
-                            pos,
-                            pos + 1,
-                            Slice.maxOpen(
-                                Fragment.fromArray([
-                                    schema.nodes.paragraph.create(),
-                                    schema.nodes.paragraph.create(),
-                                ]),
-                            ),
-                        )
-                    })
+                        // Replace each hard break with a slice that closes and re-opens a paragraph,
+                        // effectively inserting a "paragraph break" in place of a "hard break"
+                        // (this is performed in reverse order to compensate for content shifting that
+                        // occurs with each replacement, ensuring accurate insertion points)
+                        hardBreakPositions.reverse().forEach((pos) => {
+                            tr.replace(
+                                pos,
+                                pos + 1,
+                                Slice.maxOpen(
+                                    Fragment.fromArray([
+                                        schema.nodes.paragraph.create(),
+                                        schema.nodes.paragraph.create(),
+                                    ]),
+                                ),
+                            )
+                        })
+                    }
 
                     // Toggle the selection into a bullet list, optionally keeping attributes
-                    // (this is a verbatim copy of the built-in`toggleBulletList` command)
+                    // (this is a verbatim copy of the built-in `toggleBulletList` command)
 
                     if (options.keepAttributes) {
                         return chain()
@@ -85,4 +88,4 @@ const RichTextBulletList = BulletList.extend({
 
 export { RichTextBulletList }
 
-export type { BulletListOptions as RichTextBulletListOptions }
+export type { RichTextBulletListOptions }

--- a/src/extensions/rich-text/rich-text-ordered-list.ts
+++ b/src/extensions/rich-text/rich-text-ordered-list.ts
@@ -6,68 +6,71 @@ import { Fragment, Slice } from '@tiptap/pm/model'
 import type { OrderedListOptions } from '@tiptap/extension-ordered-list'
 
 /**
- * Augment the official `@tiptap/core` module with extra commands, relevant for this extension, so
- * that the compiler knows about them.
+ * The options available to customize the `RichTextOrderedList` extension.
  */
-declare module '@tiptap/core' {
-    interface Commands<ReturnType> {
-        richTextOrderedList: {
-            /**
-             * Smartly toggles the selection into an oredered list, converting any hard breaks into
-             * paragraphs before doing so.
-             *
-             * @see https://discuss.prosemirror.net/t/how-to-convert-a-selection-of-text-lines-into-paragraphs/6099
-             */
-            smartToggleOrderedList: () => ReturnType
-        }
-    }
-}
+type RichTextOrderedListOptions = {
+    /**
+     * Replace hard breaks in the selection with paragraphs before toggling the selection into a
+     * bullet list. By default, hard breaks are not replaced.
+     */
+    smartToggle: boolean
+} & OrderedListOptions
 
 /**
- * Custom extension that extends the built-in `OrderedList` extension to add a smart toggle command
- * with support for hard breaks, which are automatically converted into paragraphs before toggling
- * the selection into an ordered list.
+ * Custom extension that extends the built-in `OrderedList` extension to add an option for smart
+ * toggling, which takes into account hard breaks in the selection, and converts them into
+ * paragraphs before toggling the selection into a bullet list.
  */
-const RichTextOrderedList = OrderedList.extend({
+const RichTextOrderedList = OrderedList.extend<RichTextOrderedListOptions>({
+    addOptions() {
+        return {
+            ...this.parent?.(),
+            smartToggle: false,
+        }
+    },
+
     addCommands() {
         const { editor, name, options } = this
 
         return {
             ...this.parent?.(),
-            smartToggleOrderedList() {
+            toggleOrderedList() {
                 return ({ commands, state, tr, chain }) => {
-                    const { schema } = state
-                    const { selection } = tr
-                    const { $from, $to } = selection
+                    // Replace hard breaks in the selection with paragraphs before toggling?
+                    if (options.smartToggle) {
+                        const { schema } = state
+                        const { selection } = tr
+                        const { $from, $to } = selection
 
-                    const hardBreakPositions: number[] = []
+                        const hardBreakPositions: number[] = []
 
-                    // Find and store the positions of all hard breaks in the selection
-                    tr.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
-                        if (node.type.name === 'hardBreak') {
-                            hardBreakPositions.push(pos)
-                        }
-                    })
+                        // Find and store the positions of all hard breaks in the selection
+                        tr.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
+                            if (node.type.name === 'hardBreak') {
+                                hardBreakPositions.push(pos)
+                            }
+                        })
 
-                    // Replace each hard break with a slice that closes and re-opens a paragraph,
-                    // effectively inserting a "paragraph break" in place of a "hard break"
-                    // (this is performed in reverse order to compensate for content shifting that
-                    // occurs with each replacement, ensuring accurate insertion points)
-                    hardBreakPositions.reverse().forEach((pos) => {
-                        tr.replace(
-                            pos,
-                            pos + 1,
-                            Slice.maxOpen(
-                                Fragment.fromArray([
-                                    schema.nodes.paragraph.create(),
-                                    schema.nodes.paragraph.create(),
-                                ]),
-                            ),
-                        )
-                    })
+                        // Replace each hard break with a slice that closes and re-opens a paragraph,
+                        // effectively inserting a "paragraph break" in place of a "hard break"
+                        // (this is performed in reverse order to compensate for content shifting that
+                        // occurs with each replacement, ensuring accurate insertion points)
+                        hardBreakPositions.reverse().forEach((pos) => {
+                            tr.replace(
+                                pos,
+                                pos + 1,
+                                Slice.maxOpen(
+                                    Fragment.fromArray([
+                                        schema.nodes.paragraph.create(),
+                                        schema.nodes.paragraph.create(),
+                                    ]),
+                                ),
+                            )
+                        })
+                    }
 
                     // Toggle the selection into a bullet list, optionally keeping attributes
-                    // (this is a verbatim copy of the built-in`toggleBulletList` command)
+                    // (this is a verbatim copy of the built-in `toggleBulletList` command)
 
                     if (options.keepAttributes) {
                         return chain()
@@ -85,4 +88,4 @@ const RichTextOrderedList = OrderedList.extend({
 
 export { RichTextOrderedList }
 
-export type { OrderedListOptions as RichTextOrderedListOptions }
+export type { RichTextOrderedListOptions }

--- a/stories/typist-editor/constants/defaults.ts
+++ b/stories/typist-editor/constants/defaults.ts
@@ -116,11 +116,17 @@ const DEFAULT_STORY_ARGS: Partial<TypistEditorProps> = {
 }
 
 const DEFAULT_RICH_TEXT_KIT_OPTIONS: Partial<RichTextKitOptions> = {
+    bulletList: {
+        smartToggle: true,
+    },
     dropCursor: {
         class: 'ProseMirror-dropcursor',
     },
     link: {
         openOnClick: false,
+    },
+    orderedList: {
+        smartToggle: true,
     },
 }
 

--- a/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-toolbar.tsx
+++ b/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-toolbar.tsx
@@ -187,7 +187,7 @@ function TypistEditorToolbar({ editor }: TypistEditorToolbarProps) {
                 disabled={false}
                 icon={<RiListUnordered />}
                 variant="quaternary"
-                onClick={() => editor.chain().focus().smartToggleBulletList().run()}
+                onClick={() => editor.chain().focus().toggleBulletList().run()}
             />
             <Button
                 aria-label="Ordered List"
@@ -195,7 +195,7 @@ function TypistEditorToolbar({ editor }: TypistEditorToolbarProps) {
                 disabled={false}
                 icon={<RiListOrdered />}
                 variant="quaternary"
-                onClick={() => editor.chain().focus().smartToggleOrderedList().run()}
+                onClick={() => editor.chain().focus().toggleOrderedList().run()}
             />
             <Button
                 aria-label="Code Block"


### PR DESCRIPTION
## Overview

While updating our apps with `v2.3.1`, I realized that keyboard shortcuts were not using the new `smartToggle*List` commands, which prompted this PR.

This basically rewrites the extensions to overwrite the built-in `toggle*List` functions, where we replace hard breaks with paragraphs based on the `smartToggle` option that can now be passed into the `bulletList` and `orderedList` extensions. By default, this value is `false` and hard breaks are NOT replaced (just like the default and built-in behaviour), otherwise, if `true`, hard breaks are replaced with paragraphs, thus "smartly toggling" paragraphs/lines into bullet/ordered lists.

## PR Checklist

<!-- Feel free to remove the lines that are not applicable or leave them unchecked. -->

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Write some paragraphs, some with newlines, others without
- Make a selection of those paragraphs (select everything, select them partially, etc.)
- Click the `Bullet List` or `Ordered List` buttons in the editor toolbar
    - [x] Observe that each selected paragraph and/or newline (even partially), is converted into a bullet/ordered list
- Undo the changes to have the initial content that you wrote on step 3
- Use the `Mod-Shift+7` to toggle the selection into an ordered list
    - [x] Observe that each selected paragraph and/or newline (even partially), is converted into a bullet/ordered list
- Undo the changes to have the initial content that you wrote on step 3
- Use the `Mod-Shift+8` to toggle the selection into a bullet list
    - [x] Observe that each selected paragraph and/or newline (even partially), is converted into a bullet/ordered list

> [!NOTE]
> `Mod` is usually `Ctrl` on Windows, and `Cmd` on macOS.