### PR TITLE
fix(bold-and-italics): Disallow only whitespace in the markdown shortcuts

### DIFF
--- a/src/extensions/rich-text/bold-and-italics.ts
+++ b/src/extensions/rich-text/bold-and-italics.ts
@@ -1,9 +1,9 @@
 import { Mark, markInputRule, markPasteRule } from '@tiptap/core'
 
-const starInputRegex = /(?:^|\s)((?:\*{3})((?:[^*]+))(?:\*{3}))$/
-const starPasteRegex = /(?:^|\s)((?:\*{3})((?:[^*]+))(?:\*{3}))/g
-const underscoreInputRegex = /(?:^|\s)((?:_{3})((?:[^_]+))(?:_{3}))$/
-const underscorePasteRegex = /(?:^|\s)((?:_{3})((?:[^_]+))(?:_{3}))/g
+export const starInputRegex = /(?:^|\s)(\*\*\*(?!\s+\*\*\*)((?:[^*]+))\*\*\*(?!\s+\*\*\*))$/
+export const starPasteRegex = /(?:^|\s)(\*\*\*(?!\s+\*\*\*)((?:[^*]+))\*\*\*(?!\s+\*\*\*))/g
+export const underscoreInputRegex = /(?:^|\s)(___(?!\s+___)((?:[^_]+))___(?!\s+___))$/
+export const underscorePasteRegex = /(?:^|\s)(___(?!\s+___)((?:[^_]+))___(?!\s+___))/g
 
 /**
  * The `BoldAndItalics` extension adds the ability to use the `***` and `___` Markdown shortcuts


### PR DESCRIPTION
## Overview

This PR disallows Markdown shortcuts (through typing or pasting) for the `BoldAndItalics` mark when the content between the delimiters is only whitespace. This brings the same RegExp as implemented in this [Tiptap PR](https://github.com/ueberdosis/tiptap/pull/4866) for all the built-in marks.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
    - [ ] Observe that you can use `***<text>***` and `___<text>___` as before to have `<text>` both bold and italic
    - [ ] Observe that using `***<whitespace>***` or `___<whitespace>___` doesn't do anything

> [!TIP]
> When typing `***<space>` (or `___<space>`), an horizontal break will appear in the editor. Just press <kbd>Backspace</kbd> **once** to undo that transformation, and then you are able to continue typing more whitespace or the ending delimiter `***` (or `___`).

## Demo

![firefox_nxNAhDTJUr](https://github.com/Doist/typist/assets/96476/2a5d2190-479a-4b6d-8042-0cb00dea763d)

![firefox_lwS4OvqOlS](https://github.com/Doist/typist/assets/96476/8cda259a-7b8f-4aa3-b064-8f2fca513203)
