### PR TITLE
fix(deps): update dependency hast-util-is-element to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,7 @@
             "peerDependencies": {
                 "@react-hookz/web": "^14.2.3 || >=15.x",
                 "emoji-regex": "^10.2.1",
-                "hast-util-is-element": "^2.1.0",
+                "hast-util-is-element": "^3.0.0",
                 "linkifyjs": "^4.1.1",
                 "lodash-es": "^4.17.21",
                 "mdast-util-gfm-autolink-literal": "^2.0.0",
@@ -13488,19 +13488,6 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/hast-util-embedded/node_modules/hast-util-is-element": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
-            "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/hast-util-from-html": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.1.tgz",
@@ -13567,33 +13554,17 @@
             }
         },
         "node_modules/hast-util-is-element": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.3.tgz",
-            "integrity": "sha512-O1bKah6mhgEq2WtVMk+Ta5K7pPMqsBBlmzysLdcwKVrqzZQ0CHqUPiIVspNhAG1rvxpvJjtGee17XfauZYKqVA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+            "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
             "peer": true,
             "dependencies": {
-                "@types/hast": "^2.0.0",
-                "@types/unist": "^2.0.0"
+                "@types/hast": "^3.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
-        },
-        "node_modules/hast-util-is-element/node_modules/@types/hast": {
-            "version": "2.3.10",
-            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
-            "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
-            "peer": true,
-            "dependencies": {
-                "@types/unist": "^2"
-            }
-        },
-        "node_modules/hast-util-is-element/node_modules/@types/unist": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
-            "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==",
-            "peer": true
         },
         "node_modules/hast-util-parse-selector": {
             "version": "2.2.5",
@@ -23127,19 +23098,6 @@
                 "hast-util-is-element": "^3.0.0",
                 "hast-util-whitespace": "^3.0.0",
                 "unist-util-is": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/rehype-minify-whitespace/node_modules/hast-util-is-element": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
-            "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
-            "peer": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0"
             },
             "funding": {
                 "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "peerDependencies": {
         "@react-hookz/web": "^14.2.3 || >=15.x",
         "emoji-regex": "^10.2.1",
-        "hast-util-is-element": "^2.1.0",
+        "hast-util-is-element": "^3.0.0",
         "linkifyjs": "^4.1.1",
         "lodash-es": "^4.17.21",
         "mdast-util-gfm-autolink-literal": "^2.0.0",


### PR DESCRIPTION
## Overview

Updates `hast-util-is-element` peer dependency to v3, something that was forgotten with https://github.com/Doist/typist/pull/395. As long as all status checks are green, it should be good to go 👍

## PR Checklist

<!-- Feel free to remove the lines that are not applicable or leave them unchecked. -->

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)