### PR TITLE
fix: Prevent extra blank lines on list items

### DIFF
--- a/src/serializers/markdown/markdown.test.ts
+++ b/src/serializers/markdown/markdown.test.ts
@@ -106,6 +106,17 @@ const HTML_INPUT_UNORDERED_LISTS = `<ul>
 <li>And here&#39;s the third list item.</li>
 </ul>`
 
+const HTML_NESTED_UNORDERED_LIST = `<ul>
+<li>
+<p>Parent list element</p>
+<ul>
+<li><p>Sub-item 1</p></li>
+<li><p>Sub-item 2</p></li>
+</ul>
+</li>
+<li>And back to the first list</li>
+</ul>`
+
 const HTML_INPUT_TASK_LISTS = `<ul data-type="taskList">
 <li data-type="taskItem" data-checked="false">First item</li>
 <li data-type="taskItem" data-checked="true">Second item</li>
@@ -468,6 +479,15 @@ Strikethrough uses two tildes: ~~scratch this~~`,
 - Here's the second list item.
     I need to add another paragraph below the second list item.
 - And here's the third list item.`,
+                )
+            })
+
+            test('nested unordered lists Markdown output is correct', () => {
+                expect(markdownSerializer.serialize(HTML_NESTED_UNORDERED_LIST)).toBe(
+                    `- Parent list element
+    - Sub-item 1
+    - Sub-item 2
+- And back to the first list`,
                 )
             })
 

--- a/src/serializers/markdown/plugins/paragraph.ts
+++ b/src/serializers/markdown/plugins/paragraph.ts
@@ -3,7 +3,8 @@ import type Turndown from 'turndown'
 
 /**
  * A Turndown plugin which adds a custom rule for paragraphs. This custom rule is required to avoid
- * adding unnecessary blank lines between paragraphs to plain-text documents.
+ * adding unnecessary blank lines between paragraphs to plain-text documents, and to list items in
+ * rich-text documents.
  *
  * @param nodeType The node object that matches this rule.
  * @param isPlainText Specifies if the schema represents a plain-text document.
@@ -12,8 +13,14 @@ function paragraph(nodeType: NodeType, isPlainText: boolean): Turndown.Plugin {
     return (turndown: Turndown) => {
         turndown.addRule(nodeType.name, {
             filter: 'p',
-            replacement(content) {
-                return isPlainText ? `\n${content}\n` : `\n\n${content}\n\n`
+            replacement(content, node) {
+                const useSingleLineSpacing =
+                    isPlainText ||
+                    // Paragraphs within list items should be wrapped with a single line feed to
+                    // maintain proper list formatting in rich-text documents.
+                    (!isPlainText && node.parentNode?.nodeName === 'LI')
+
+                return useSingleLineSpacing ? `\n${content}\n` : `\n\n${content}\n\n`
             },
         })
     }


### PR DESCRIPTION
<!-- Thank you for your contribution to the Typist repository. -->

<!-- Please remove all sections that are not relevant. -->

## Overview

This PR applies a fix devised by Ricardo in https://github.com/Doist/Issues/issues/13081#issuecomment-1980648452. Once this is released in a new Typist version, and incorporated into todoist-web, that issue will be fixed.

## PR Checklist

<!-- Feel free to remove the lines that are not applicable or leave them unchecked. -->

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
-   [x] Added/updated unit test cases and/or end-to-end test cases
-   [ ] Added/updated documentation to Storybook or `README.md`

## Test plan

See demo below. Check that in this PR's storybooks deployment the issue does not happen anymore.

## Demo

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>

https://github.com/Doist/typist/assets/15199/77c88c35-e533-4df1-993d-2d0c3f8815c9

</td><td>

https://github.com/Doist/typist/assets/15199/ec579036-e02c-491b-bc61-d89427c3dc66

</td></tr>
</tbody>
</table>
