### PR TITLE
chore!: Remove unused `onImageNodeDelete` option

### DIFF
--- a/src/extensions/rich-text/rich-text-image.ts
+++ b/src/extensions/rich-text/rich-text-image.ts
@@ -63,7 +63,7 @@ type RichTextImageOptions = {
     acceptedImageMimeTypes: string[]
 
     /**
-     * Renders the image node inline (e.g., <p><img src="spacer.gif"></p>). By default images are on
+     * Renders the image node inline (e.g., <p><img src="doist.jpg"></p>). By default images are on
      * the same level as paragraphs.
      */
     inline: boolean
@@ -82,11 +82,6 @@ type RichTextImageOptions = {
      * The event handler that is fired when an image file is pasted.
      */
     onImageFilePaste?: (file: File) => void
-
-    /**
-     * The event handler that should be fired when an image node is deleted.
-     */
-    onImageNodeDelete?: (attachmentId: string) => void
 }
 
 /**


### PR DESCRIPTION
## Overview

This option was previously unused and was not intended for consumer use. However, its removal technically constitutes a breaking change, so we have marked it accordingly.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

Green status checks are more than enough for this one.