### PR TITLE
refactor!: Use a wildcard export for ProseMirror model, state and view

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,10 +77,9 @@ export {
 } from '@tiptap/core'
 export { Extension, Mark } from '@tiptap/core'
 export * from '@tiptap/extension-character-count'
-export { DOMParser, Fragment, Node as ProseMirrorNode } from '@tiptap/pm/model'
-export type { Selection, Transaction } from '@tiptap/pm/state'
-export { EditorState, Plugin, PluginKey } from '@tiptap/pm/state'
-export type { EditorView } from '@tiptap/pm/view'
+export * as ProseMirrorModel from '@tiptap/pm/model'
+export * as ProseMirrorState from '@tiptap/pm/state'
+export * as ProseMirrorView from '@tiptap/pm/view'
 export type { Editor, NodeViewProps, ReactRendererOptions } from '@tiptap/react'
 export { NodeViewWrapper, ReactRenderer } from '@tiptap/react'
 export type {

--- a/stories/typist-editor/plain-text.stories.tsx
+++ b/stories/typist-editor/plain-text.stories.tsx
@@ -10,7 +10,7 @@ import { HashtagSuggestion } from './extensions/hashtag-suggestion'
 import { MentionSuggestion } from './extensions/mention-suggestion'
 
 import type { Meta, StoryObj } from '@storybook/react'
-import type { EditorView } from '../../src'
+import type { EditorView } from '@tiptap/pm/view'
 
 const meta: Meta<typeof TypistEditor> = {
     title: 'Typist Editor/Plain-text',

--- a/stories/typist-editor/rich-text.stories.tsx
+++ b/stories/typist-editor/rich-text.stories.tsx
@@ -17,7 +17,8 @@ import { RichTextImageWrapper } from './wrappers/rich-text-image-wrapper'
 
 import type { Meta, StoryObj } from '@storybook/react'
 import type { Extensions } from '@tiptap/core'
-import type { EditorView, TypistEditorRef } from '../../src'
+import type { EditorView } from '@tiptap/pm/view'
+import type { TypistEditorRef } from '../../src'
 
 const meta: Meta<typeof TypistEditor> = {
     title: 'Typist Editor/Rich-text',


### PR DESCRIPTION
## Overview

More often than not, we need to import things from ProseMirror related packages on our consumer applications, and so far we've been exporting exactly what we need when needed. This slows us down a bit, because it forces us to do some work on Typist when something we need is not yet exported.

We (I discussed this with Pedro) decided that it would be best to remove this step in the workflow, and for that reason we will now start **exporting everything** in the `@tiptap/pm/*` packages as wildcard `ProseMirror*` exports.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)