### PR TITLE
fix(rich-text-link): Change `openOnClick` default to `whenNotEditable`

### DIFF
--- a/src/extensions/rich-text/rich-text-link.ts
+++ b/src/extensions/rich-text/rich-text-link.ts
@@ -63,6 +63,12 @@ function linkPasteRule(config: Parameters<typeof markPasteRule>[0]) {
  */
 const RichTextLink = Link.extend({
     inclusive: false,
+    addOptions() {
+        return {
+            ...this.parent?.(),
+            openOnClick: 'whenNotEditable' as LinkOptions['openOnClick'],
+        }
+    },
     addAttributes() {
         return {
             ...this.parent?.(),

--- a/stories/typist-editor/constants/defaults.ts
+++ b/stories/typist-editor/constants/defaults.ts
@@ -122,9 +122,6 @@ const DEFAULT_RICH_TEXT_KIT_OPTIONS: Partial<RichTextKitOptions> = {
     dropCursor: {
         class: 'ProseMirror-dropcursor',
     },
-    link: {
-        openOnClick: false,
-    },
     orderedList: {
         smartToggle: true,
     },


### PR DESCRIPTION
## Overview

The goal of this change is to provide sane defaults for Typist., and in this case we take advantage of a new `Link` option in the latest Tiptap version where we can finally define that we want link clicks to NOT open when clicking them, but **only when the editor is editable**. 

> [!TIP]
> This allows us to remove the `link: { openOnClick: false }` configuration option that we pass to the `RichTextKit.configure()` call in most of our editor usages in both Todoist and Twist.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

> [!NOTE]
> I've written a test plan, but this is still a `show` PR because it's a very simple change.

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Add some text and some link
    - For instance, type `doist.dev<space>`
- Click anywhere in the `doist.dev` text
    - [ ] Observe that the link does NOT open