### PR TITLE
fix: Check `code` mark presence instead of any mark in `canInsertSuggestion`

### DIFF
--- a/src/utilities/can-insert-suggestion.ts
+++ b/src/utilities/can-insert-suggestion.ts
@@ -14,12 +14,14 @@ function canInsertSuggestion({ editor, state }: { editor: Editor; state: EditorS
     const isInsideCodeBlockNode = selection.$from.parent.type.name === 'codeBlock'
 
     const wordsBeforeSelection = (selection.$from.nodeBefore?.text ?? '').split(' ')
+    const nodeBeforeSelection = selection.$from.parent.cut(
+        selection.$from.parentOffset - wordsBeforeSelection.slice(-1)[0].length - 1,
+        selection.$from.parentOffset - 1,
+    ).content.firstChild
 
-    const hasCodeMarkBefore =
-        (selection.$from.parent.cut(
-            selection.$from.parentOffset - wordsBeforeSelection.slice(-1)[0].length - 1,
-            selection.$from.parentOffset - 1,
-        ).content.firstChild?.marks.length ?? 0) > 0
+    const hasCodeMarkBefore = (nodeBeforeSelection?.marks ?? []).some(
+        (mark) => mark.type.name === 'code',
+    )
 
     const isComposingInlineCode = wordsBeforeSelection.some((word) => word.startsWith('`'))
 


### PR DESCRIPTION
## Overview

This PR addresses an issue in the `canInsertSuggestion` function where it was incorrectly checking for the presence of any mark in the node before the selection, rather than specifically checking for a `code` mark. The fix ensures that the function now verifies the existence of a `code` mark before determining if a suggestion can be inserted.

### References

- https://github.com/Doist/Issues/issues/13800

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Type `**bold** ` (yes, that's a <kbd>space</kbd> character at the end)
- Type `@`
    - [ ] Observe that the mention suggestions popover is triggered
- Pick any user from the suggestions popopver
    - [ ] Observe that the user was correctly mentioned
- Clear all the editor content
- Open an inline code mark with <kbd>`</kbd> and type some text afterwards ending with a space
    - This is similar to the bold example above, but you don't terminate the inline code
- Type `@`
    - [ ] Observe that the mention suggestions popover is NOT triggered
- Terminate the inline code mark with another <kbd>`</kbd> and end with a space
- Type `@`
    - [ ] Observe that the mention suggestions popover is now triggered