### PR TITLE
fix: Remove `@react-hookz/web` peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,6 @@
                 "npm": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
             },
             "peerDependencies": {
-                "@react-hookz/web": "^14.2.3 || >=15.x",
                 "emoji-regex": "^10.2.1",
                 "hast-util-is-element": "^3.0.0",
                 "linkifyjs": "^4.1.1",
@@ -3803,34 +3802,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
-            }
-        },
-        "node_modules/@react-hookz/deep-equal": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@react-hookz/deep-equal/-/deep-equal-1.0.4.tgz",
-            "integrity": "sha512-N56fTrAPUDz/R423pag+n6TXWbvlBZDtTehaGFjK0InmN+V2OFWLE/WmORhmn6Ce7dlwH5+tQN1LJFw3ngTJVg==",
-            "peer": true
-        },
-        "node_modules/@react-hookz/web": {
-            "version": "24.0.4",
-            "resolved": "https://registry.npmjs.org/@react-hookz/web/-/web-24.0.4.tgz",
-            "integrity": "sha512-DcIM6JiZklDyHF6CRD1FTXzuggAkQ+3Ncq2Wln7Kdih8GV6ZIeN9JfS6ZaQxpQUxan8/4n0J2V/R7nMeiSrb2Q==",
-            "peer": true,
-            "dependencies": {
-                "@react-hookz/deep-equal": "^1.0.4"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            },
-            "peerDependencies": {
-                "js-cookie": "^3.0.5",
-                "react": "^16.8 || ^17 || ^18",
-                "react-dom": "^16.8 || ^17 || ^18"
-            },
-            "peerDependenciesMeta": {
-                "js-cookie": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@remirror/core-constants": {

--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
         "vitest": "2.0.4"
     },
     "peerDependencies": {
-        "@react-hookz/web": "^14.2.3 || >=15.x",
         "emoji-regex": "^10.2.1",
         "hast-util-is-element": "^3.0.0",
         "linkifyjs": "^4.1.1",

--- a/src/hooks/use-editor.ts
+++ b/src/hooks/use-editor.ts
@@ -1,9 +1,28 @@
-import { DependencyList, useEffect, useState } from 'react'
+import { DependencyList, useCallback, useEffect, useState } from 'react'
 
-import { useRerender } from '@react-hookz/web'
 import { Editor } from '@tiptap/react'
 
 import type { EditorOptions } from '@tiptap/core'
+
+function stateChanger(state: number) {
+    return (state + 1) % Number.MAX_SAFE_INTEGER
+}
+
+/**
+ * This is a copy of the `useRerender` hook from `@react-hookz/web`, which is a utility hook that
+ * returns a function that can be called to force a re-render of the component.
+ *
+ * Turns out we don't have the need to use any of the other hooks from `@react-hookz/web`, which is
+ * a peer dependency that often introduces breaking changes, causing upgrade issues across our
+ * projects.
+ */
+function useRerender(): () => void {
+    const [, setState] = useState(0)
+
+    return useCallback(() => {
+        setState(stateChanger)
+    }, [])
+}
 
 /**
  * This is a fork of the official `useEditor` hook with one key difference, which is to prevent a

--- a/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-toolbar.tsx
+++ b/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-toolbar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useReducer } from 'react'
 import {
     RiArrowGoBackLine,
     RiArrowGoForwardLine,
@@ -28,8 +28,6 @@ import {
 
 import { Box, Button } from '@doist/reactist'
 
-import { useRerender } from '@react-hookz/web'
-
 import styles from './typist-editor-toolbar.module.css'
 
 import type { CoreEditor } from '../../../../src'
@@ -41,7 +39,7 @@ type TypistEditorToolbarProps = {
 function TypistEditorToolbar({ editor }: TypistEditorToolbarProps) {
     const isCursorOverLink = Boolean(editor.getAttributes('link').href)
 
-    const forceRerender = useRerender()
+    const [, forceRerender] = useReducer((x: number) => x + 1, 0)
 
     useEffect(
         function initializeEventListeners() {


### PR DESCRIPTION
## Overview

The `@react-hookz/web` peer dependency might cause issues upgrading Typist to a newer version (especially when running an older version, such is the case for Twist), and the fact of the matter is that we are only using one hook from the whole library, a hook that we can easily copy/paste into Typist code base.

That one hook, `useRerender`, was mostly being used by the `useEditor` hook (and also a Storybook component, but we can easily refactor that with a different technique), a fork of the official `useEditor` from Tiptap to cater to our needs. However, the latest Tiptap versions come with a much better `useEditor` implementation, making our version redundant. Soon we'll move back to the official `useEditor` hook, removing the need for `@react-hookz/web`.

There's no point in keeping the `@react-hookz/web` library around (especially as a peer dependency), and this PR prepares the code base `useEditor` hook upgrade by removing the library altogether.

> [!IMPORTANT]
> Although this removes a peer dependency, this is not a breaking change, and consumer apps don't need any changes.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- If the editor loads and works as expected, there's nothing else to test.