### PR TITLE
fix(paste-markdown): Escape backslashes before punctuation

### DIFF
--- a/src/extensions/rich-text/paste-markdown.ts
+++ b/src/extensions/rich-text/paste-markdown.ts
@@ -5,6 +5,7 @@ import * as linkify from 'linkifyjs'
 
 import { ClipboardDataType } from '../../constants/common'
 import { PASTE_MARKDOWN_EXTENSION_PRIORITY } from '../../constants/extension-priorities'
+import { REGEX_PUNCTUATION } from '../../constants/regular-expressions'
 
 /**
  * A partial type for the the clipboard metadata coming from VS Code.
@@ -110,9 +111,17 @@ const PasteMarkdown = Extension.create({
                             return false
                         }
 
+                        // Escape all backslash characters that precede any punctuation marks, to
+                        // prevent the backslash itself from being interpreted as an escape sequence
+                        // for the subsequent character.
+                        const escapedTextContent = textContent.replace(
+                            new RegExp(`(\\\\${REGEX_PUNCTUATION.source})`, 'g'),
+                            '\\$1',
+                        )
+
                         // Send the clipboard text through the HTML serializer to convert potential
                         // Markdown into HTML, and then insert it into the editor
-                        editor.commands.insertMarkdownContent(textContent)
+                        editor.commands.insertMarkdownContent(escapedTextContent)
 
                         // Suppress the default handling behaviour
                         return true

--- a/src/serializers/markdown/markdown.ts
+++ b/src/serializers/markdown/markdown.ts
@@ -114,11 +114,10 @@ function createMarkdownSerializer(schema: Schema): MarkdownSerializerReturnType 
         turndown.escape = (str) => {
             return (
                 str
-                    // Escape all backslash characters that precedes any punctuation characters,
-                    // otherwise the backslash character itself will be interpreted as escaping the
-                    // character that comes after it (which is not the intent). It's important that
-                    // this escape rule is executed before all other escape rules, otherwise we
-                    // could be double escaping some backslash characters.
+                    // Escape all backslash characters that precede any punctuation marks, to
+                    // prevent the backslash itself from being interpreted as an escape sequence
+                    // for the subsequent character. It's important to apply this rule first to
+                    // avoid double escaping.
                     .replace(new RegExp(`(\\\\${REGEX_PUNCTUATION.source})`, 'g'), '\\$1')
 
                     // Although the CommonMark specification allows for bulleted or ordered lists


### PR DESCRIPTION
## Overview

This PR addresses an issue where backslashes (\) in pasted content are mistakenly interpreted as escape sequences, leading to the unintended removal of the backslash. This behavior occurs because the source of the pasted content is often unknown, and the backslashes are not properly escaped.

To prevent this, the PR introduces a solution that automatically escapes all backslashes that appear before punctuation marks. This ensures that the backslashes are not misinterpreted as escape characters, preserving the intended content during the paste operation.

This will help with this [internal issue](https://github.com/Doist/Issues/issues/14404).

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Copy the following text: `C:\Folder\_FooBar`
- Paste into the editor with <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>V</kbd>
    - [ ] Observe that the output in **Typist Editor** is `C:\Folder\_FooBar`
    - [ ] Observe that the output in **Markdown Output** is `C:\Folder\\_FooBar`
