### PR TITLE
fix: Empty list items returns incorrectly formatted Markdown

### DIFF
--- a/src/serializers/markdown/markdown.test.ts
+++ b/src/serializers/markdown/markdown.test.ts
@@ -64,6 +64,12 @@ const HTML_INPUT_ORDERED_LISTS = `<ol>
 <li>Fourth item</li>
 </ol>
 <hr>
+<ol>
+<li>First item</li>
+<li></li>
+<li>Third item</li>
+</ol>
+<hr>
 <ol start="5">
 <li>First item</li>
 <li>Second item</li>
@@ -87,6 +93,12 @@ const HTML_INPUT_UNORDERED_LISTS = `<ul>
 <li>Second item</li>
 <li>Third item</li>
 <li>Fourth item</li>
+</ul>
+<hr>
+<ul>
+<li>First item</li>
+<li></li>
+<li>Third item</li>
 </ul>
 <hr>
 <ul>
@@ -447,6 +459,12 @@ Strikethrough uses two tildes: ~~scratch this~~`,
 
 ---
 
+1. First item
+2.
+3. Third item
+
+---
+
 5. First item
 6. Second item
 7. Third item
@@ -468,6 +486,12 @@ Strikethrough uses two tildes: ~~scratch this~~`,
 - Second item
 - Third item
 - Fourth item
+
+---
+
+- First item
+-
+- Third item
 
 ---
 
@@ -725,6 +749,12 @@ See the section on [\`code\`](#code).`,
 
 ---
 
+1.  First item
+2.
+3.  Third item
+
+---
+
 5.  First item
 6.  Second item
 7.  Third item
@@ -746,6 +776,12 @@ See the section on [\`code\`](#code).`,
 -   Second item
 -   Third item
 -   Fourth item
+
+---
+
+-   First item
+-
+-   Third item
 
 ---
 

--- a/src/serializers/markdown/markdown.ts
+++ b/src/serializers/markdown/markdown.ts
@@ -62,7 +62,7 @@ const INITIAL_TURNDOWN_OPTIONS: Turndown.Options = {
 
         // Return the list marker for empty bullet list items
         if (node.nodeName === 'UL' || (parentNode?.nodeName === 'UL' && node.nodeName === 'LI')) {
-            return `${BULLET_LIST_MARKER} `
+            return `${BULLET_LIST_MARKER} \n`
         }
 
         // Return the list marker for empty ordered list items
@@ -73,7 +73,7 @@ const INITIAL_TURNDOWN_OPTIONS: Turndown.Options = {
                     : (node as HTMLElement).getAttribute('start')
             const index = Array.prototype.indexOf.call(parentNode.children, node)
 
-            return `${start ? Number(start) + index : index + 1}. `
+            return `${start ? Number(start) + index : index + 1}. \n`
         }
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
## Overview

This fixes an internal issue https://github.com/Doist/Issues/issues/14669 where empty list items (both for ordered and bullet lists) would return incorrectly formatted Markdown (see test plan below).

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
-   [x] Added/updated unit test cases and/or end-to-end test cases

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Type `-<space>One`
- Type `<Enter>`
- Type `Two`
- Insert an empty item between `One` and `Two`
    - [ ] Observe that the **Markdown Output** shows the expected Markdown

## Demo

| Before                      | After                      |
| --------------------------- | -------------------------- |
| ![image](https://github.com/user-attachments/assets/a1b1dd36-0bdc-4554-b48e-928092f5065b) | ![image](https://github.com/user-attachments/assets/7d53db4a-d51e-4d71-8370-5349df20d5d5) |
