### PR TITLE
refactor: General improvements for TypeScript types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
                 "react-icons": "5.3.0",
                 "react-markdown": "9.0.1",
                 "react-syntax-highlighter": "15.5.0",
+                "react-use-event-hook": "0.9.6",
                 "rehype-raw": "7.0.0",
                 "remark-gfm": "4.0.0",
                 "rimraf": "6.0.1",
@@ -19966,6 +19967,15 @@
             },
             "peerDependencies": {
                 "react": ">= 0.14.0"
+            }
+        },
+        "node_modules/react-use-event-hook": {
+            "version": "0.9.6",
+            "resolved": "https://registry.npmjs.org/react-use-event-hook/-/react-use-event-hook-0.9.6.tgz",
+            "integrity": "sha512-wNchkFrrlz64QQOJOf5+dFjy+27bJEwtS1SgliRXVsU60wo3pSntNRlwDws2qPHwrAP/wlm5IyQHBlPCya0JIQ==",
+            "dev": true,
+            "peerDependencies": {
+                "react": ">=16.8.0"
             }
         },
         "node_modules/read-package-json-fast": {

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
         "react-icons": "5.3.0",
         "react-markdown": "9.0.1",
         "react-syntax-highlighter": "15.5.0",
+        "react-use-event-hook": "0.9.6",
         "rehype-raw": "7.0.0",
         "remark-gfm": "4.0.0",
         "rimraf": "6.0.1",

--- a/src/extensions/rich-text/rich-text-code.ts
+++ b/src/extensions/rich-text/rich-text-code.ts
@@ -2,6 +2,13 @@ import { Code } from '@tiptap/extension-code'
 
 import { CODE_EXTENSION_PRIORITY } from '../../constants/extension-priorities'
 
+import type { CodeOptions } from '@tiptap/extension-code'
+
+/**
+ * The options available to customize the `RichTextCode` extension.
+ */
+type RichTextCodeOptions = CodeOptions
+
 /**
  * Custom extension that extends the built-in `Code` extension to allow all marks (e.g., Bold,
  * Italic, and Strikethrough) to coexist with the `Code` mark (as opposed to disallowing all any
@@ -10,9 +17,11 @@ import { CODE_EXTENSION_PRIORITY } from '../../constants/extension-priorities'
  * @see https://tiptap.dev/api/schema#excludes
  * @see https://prosemirror.net/docs/ref/#model.MarkSpec.excludes
  */
-const RichTextCode = Code.extend({
+const RichTextCode = Code.extend<RichTextCodeOptions>({
     priority: CODE_EXTENSION_PRIORITY,
     excludes: Code.name,
 })
 
 export { RichTextCode }
+
+export type { RichTextCodeOptions }

--- a/src/extensions/rich-text/rich-text-link.ts
+++ b/src/extensions/rich-text/rich-text-link.ts
@@ -57,16 +57,21 @@ function linkPasteRule(config: Parameters<typeof markPasteRule>[0]) {
 }
 
 /**
+ * The options available to customize the `RichTextLink` extension.
+ */
+type RichTextLinkOptions = LinkOptions
+
+/**
  * Custom extension that extends the built-in `Link` extension to add additional input/paste rules
  * for converting the Markdown link syntax (i.e. `[Doist](https://doist.com)`) into links, and also
  * adds support for the `title` attribute.
  */
-const RichTextLink = Link.extend({
+const RichTextLink = Link.extend<RichTextLinkOptions>({
     inclusive: false,
     addOptions() {
         return {
             ...this.parent?.(),
-            openOnClick: 'whenNotEditable' as LinkOptions['openOnClick'],
+            openOnClick: 'whenNotEditable',
         }
     },
     addAttributes() {
@@ -117,4 +122,4 @@ const RichTextLink = Link.extend({
 
 export { RichTextLink }
 
-export type { LinkOptions as RichTextLinkOptions }
+export type { RichTextLinkOptions }

--- a/src/extensions/rich-text/rich-text-strikethrough.ts
+++ b/src/extensions/rich-text/rich-text-strikethrough.ts
@@ -3,9 +3,14 @@ import { Strike } from '@tiptap/extension-strike'
 import type { StrikeOptions } from '@tiptap/extension-strike'
 
 /**
+ * The options available to customize the `RichTextStrikethrough` extension.
+ */
+type RichTextStrikethroughOptions = StrikeOptions
+
+/**
  * Custom extension that extends the built-in `Strike` extension to overwrite the default keyboard.
  */
-const RichTextStrikethrough = Strike.extend({
+const RichTextStrikethrough = Strike.extend<RichTextStrikethroughOptions>({
     addKeyboardShortcuts() {
         return {
             'Mod-Shift-x': () => this.editor.commands.toggleStrike(),
@@ -15,4 +20,4 @@ const RichTextStrikethrough = Strike.extend({
 
 export { RichTextStrikethrough }
 
-export type { StrikeOptions as RichTextStrikethroughOptions }
+export type { RichTextStrikethroughOptions }

--- a/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-decorator.tsx
+++ b/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-decorator.tsx
@@ -22,7 +22,7 @@ type TypistEditorDecoratorProps = {
     Story: PartialStoryFn<ReactRenderer, TypistEditorPropsWithRef>
     args: TypistEditorProps
     withToolbar?: boolean
-    renderBottomFunctions?: () => JSX.Element
+    renderBottomFunctions?: () => React.ReactElement
 }
 
 const TypistEditorDecorator = forwardRef<TypistEditorRef, TypistEditorDecoratorProps>(

--- a/stories/typist-editor/extensions/suggestions/base-suggestion-dropdown.tsx
+++ b/stories/typist-editor/extensions/suggestions/base-suggestion-dropdown.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import { useEffect, useImperativeHandle, useRef, useState } from 'react'
 
 import { Box, Inline, Text } from '@doist/reactist'
 
@@ -6,21 +6,21 @@ import { SuggestionRendererRef } from '../../../../src'
 
 import styles from './base-suggestion-dropdown.module.css'
 
-type BaseSuggestionDropdownProps<TItem> = {
+type BaseSuggestionDropdownProps<TSuggestionItem> = {
     forwardedRef: React.ForwardedRef<SuggestionRendererRef>
-    items: TItem[]
+    items: TSuggestionItem[]
     itemSize?: number
-    renderItem: (item: TItem) => JSX.Element
-    onItemSelect: (item: TItem) => void
+    renderItem: (item: TSuggestionItem) => React.ReactElement
+    onItemSelect: (index: number) => void
 }
 
-function BaseSuggestionDropdown<TItem extends object>({
+function BaseSuggestionDropdown<TSuggestionItem extends object>({
     forwardedRef,
     items,
     itemSize = 6,
     renderItem,
     onItemSelect,
-}: BaseSuggestionDropdownProps<TItem>): JSX.Element | null {
+}: BaseSuggestionDropdownProps<TSuggestionItem>) {
     const selectedItemRef = useRef<HTMLLIElement>(null)
     const [selectedIndex, setSelectedIndex] = useState(0)
 
@@ -30,17 +30,6 @@ function BaseSuggestionDropdown<TItem extends object>({
 
     const areSuggestionsLoading = items.length === 1 && 'isLoading' in items[0]
     const areSuggestionsEmpty = items.length === 0
-
-    const handleItemSelect = useCallback(
-        (index: number) => {
-            const item = items[index]
-
-            if (item) {
-                onItemSelect(item)
-            }
-        },
-        [items, onItemSelect],
-    )
 
     useEffect(
         function scrollSelectedItemIntoView() {
@@ -76,7 +65,7 @@ function BaseSuggestionDropdown<TItem extends object>({
                     }
 
                     if (event.key === 'Enter') {
-                        handleItemSelect(selectedIndex)
+                        onItemSelect(selectedIndex)
                         return true
                     }
 
@@ -84,7 +73,7 @@ function BaseSuggestionDropdown<TItem extends object>({
                 },
             }
         },
-        [items.length, handleItemSelect, selectedIndex],
+        [items.length, onItemSelect, selectedIndex],
     )
 
     return (
@@ -135,7 +124,7 @@ function BaseSuggestionDropdown<TItem extends object>({
                             display="flex"
                             alignItems="center"
                             borderRadius="standard"
-                            onClick={() => handleItemSelect(index)}
+                            onClick={() => onItemSelect(index)}
                             ref={index === selectedIndex ? selectedItemRef : null}
                         >
                             {renderItem(item)}

--- a/stories/typist-editor/extensions/suggestions/hashtag-suggestion-dropdown.tsx
+++ b/stories/typist-editor/extensions/suggestions/hashtag-suggestion-dropdown.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from 'react'
+import { useEvent } from 'react-use-event-hook'
 
 import { Inline, Text } from '@doist/reactist'
 
@@ -15,11 +16,22 @@ const HashtagSuggestionDropdown = forwardRef<
     SuggestionRendererRef,
     SuggestionRendererProps<HashtagSuggestionItem>
 >(function HashtagSuggestionDropdown({ items, command }, ref) {
+    const handleItemSelect = useEvent((index: number) => {
+        const item = items[index] as HashtagSuggestionItem | undefined
+
+        if (item) {
+            command({
+                id: item.id,
+                label: item.name,
+            })
+        }
+    })
+
     return (
         <BaseSuggestionDropdown
             forwardedRef={ref}
             items={items}
-            onItemSelect={command}
+            onItemSelect={handleItemSelect}
             renderItem={(item) => (
                 <Inline space="small" exceptionallySetClassName={styles.hashtagSuggestionItem}>
                     <Avatar

--- a/stories/typist-editor/extensions/suggestions/mention-suggestion-dropdown.tsx
+++ b/stories/typist-editor/extensions/suggestions/mention-suggestion-dropdown.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from 'react'
+import { useEvent } from 'react-use-event-hook'
 
 import { Inline, Text } from '@doist/reactist'
 
@@ -15,11 +16,22 @@ const MentionSuggestionDropdown = forwardRef<
     SuggestionRendererRef,
     SuggestionRendererProps<MentionSuggestionItem>
 >(function MentionSuggestionDropdown({ items, command }, ref) {
+    const handleItemSelect = useEvent((index: number) => {
+        const item = items[index] as MentionSuggestionItem | undefined
+
+        if (item) {
+            command({
+                id: item.uid,
+                label: item.name,
+            })
+        }
+    })
+
     return (
         <BaseSuggestionDropdown
             forwardedRef={ref}
             items={items}
-            onItemSelect={command}
+            onItemSelect={handleItemSelect}
             renderItem={(item) => (
                 <Inline space="small" exceptionallySetClassName={styles.mentionSuggestionItem}>
                     <Avatar


### PR DESCRIPTION
## Overview

BREAKING CHANGE: Fix TypeScript types for the Suggestion plugin `command` function (allowing for generic override).

Although this was not causing any issues for us due to the convoluted implementation, the [same fix was recently applied to Tiptap](https://github.com/ueberdosis/tiptap/pull/4136), and this aligns our suggestion factory function implementation with the original one. Unfortunately, this comes as a breaking change (examples were also updated to reflect the required changes).

Additionally, other smaller TypeScript types were refactored for consistency and clarity, but these are safe changes.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

> [!TIP]
> "work as expected" in the context of mentions and hashtags means that the suggestions are shown correctly, they can be inserted into the editor without issues, the Markdown output is as before, the HTML (inspect the DOM) is as before, and the the `onMentionItemSelect` output in the "Actions" tab (at the bottom of the Storybook) is also as before. Feel free to compare the preview Storybook with the [production one](https://typist.doist.dev).

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Use mentions with `@`
    - [ ] Observe that they continue to work as expected
- Use hashtags with `#`
    - [ ] Observe that they continue to work as expected