### PR TITLE
chore(storybook): Prevent `keyDown` propagation with hidden suggestion dropdown

### DIFF
--- a/stories/typist-editor/extensions/hashtag-suggestion.ts
+++ b/stories/typist-editor/extensions/hashtag-suggestion.ts
@@ -44,8 +44,10 @@ const HashtagSuggestion: SuggestionExtensionResult<HashtagSuggestionItem> =
 
             // These flag variables control when the renderer functions are allowed to be called,
             // and they are needed to work around a few issues with Tiptap's suggestion utility:
+            //   * https://github.com/ueberdosis/tiptap/issues/214
             //   * https://github.com/ueberdosis/tiptap/issues/2547
             //   * https://github.com/ueberdosis/tiptap/issues/2592
+            let isDropdownHidden = false
             let isDropdownInitialized = false
             let wasDropdownDestroyed = false
 
@@ -70,6 +72,12 @@ const HashtagSuggestion: SuggestionExtensionResult<HashtagSuggestionItem> =
                         },
                         getReferenceClientRect() {
                             return props.clientRect?.() || DOM_RECT_FALLBACK
+                        },
+                        onHide() {
+                            isDropdownHidden = true
+                        },
+                        onShow() {
+                            isDropdownHidden = false
                         },
                         content: reactRenderer.element,
                         duration: [150, 200],
@@ -124,13 +132,12 @@ const HashtagSuggestion: SuggestionExtensionResult<HashtagSuggestionItem> =
                     })
                 },
                 onKeyDown(props) {
-                    if (!isDropdownInitialized) {
+                    if (!isDropdownInitialized || isDropdownHidden) {
                         return false
                     }
 
                     if (props.event.key === 'Escape') {
-                        dropdown[0].destroy()
-                        reactRenderer.destroy()
+                        dropdown[0].hide()
                         return true
                     }
 

--- a/stories/typist-editor/extensions/mention-suggestion.ts
+++ b/stories/typist-editor/extensions/mention-suggestion.ts
@@ -40,8 +40,10 @@ const MentionSuggestion: SuggestionExtensionResult<MentionSuggestionItem> =
 
             // These flag variables control when the renderer functions are allowed to be called,
             // and they are needed to work around a few issues with Tiptap's suggestion utility:
+            //   * https://github.com/ueberdosis/tiptap/issues/214
             //   * https://github.com/ueberdosis/tiptap/issues/2547
             //   * https://github.com/ueberdosis/tiptap/issues/2592
+            let isDropdownHidden = false
             let isDropdownInitialized = false
             let wasDropdownDestroyed = false
 
@@ -63,6 +65,12 @@ const MentionSuggestion: SuggestionExtensionResult<MentionSuggestionItem> =
                         },
                         getReferenceClientRect() {
                             return props.clientRect?.() || DOM_RECT_FALLBACK
+                        },
+                        onHide() {
+                            isDropdownHidden = true
+                        },
+                        onShow() {
+                            isDropdownHidden = false
                         },
                         content: reactRenderer.element,
                         duration: [150, 200],
@@ -88,7 +96,7 @@ const MentionSuggestion: SuggestionExtensionResult<MentionSuggestionItem> =
                     })
                 },
                 onKeyDown(props) {
-                    if (!isDropdownInitialized) {
+                    if (!isDropdownInitialized || isDropdownHidden) {
                         return false
                     }
 


### PR DESCRIPTION
## Overview

Both the `Mention` and `Hashtag` suggestion dropdowns have an issue where any `keyDown` event is propagated to the dropdown renderer component after the dropdown has been hidden. This PR fixes that by detecting whether the dropdown is hidden or not, and disallowing the `keyDown` event propagation in case it's hidden.

> [!NOTE]
> This does not affect the production Typist build, it only fixes the Storybook examples.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)