### PR TITLE
chore: Upgrade to `actions/cache@v4`

### DIFF
--- a/.github/workflows/check-ci-validation.yml
+++ b/.github/workflows/check-ci-validation.yml
@@ -33,7 +33,7 @@ jobs:
                   node-version-file: .node-version
 
             - name: Cache project 'node_modules' directory
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: node-modules-cache
               with:
                   key: node-modules-cache-${{ hashFiles('**/package-lock.json', '**/.node-version') }}
@@ -63,7 +63,7 @@ jobs:
                   node-version-file: .node-version
 
             - name: Cache project 'node_modules' directory
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: node-modules-cache
               with:
                   key: node-modules-cache-${{ hashFiles('**/package-lock.json', '**/.node-version') }}
@@ -105,7 +105,7 @@ jobs:
                   node-version-file: .node-version
 
             - name: Cache project 'node_modules' directory
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: node-modules-cache
               with:
                   key: node-modules-cache-${{ hashFiles('**/package-lock.json', '**/.node-version') }}
@@ -139,7 +139,7 @@ jobs:
                   node-version-file: .node-version
 
             - name: Cache project 'node_modules' directory
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: node-modules-cache
               with:
                   key: node-modules-cache-${{ hashFiles('**/package-lock.json', '**/.node-version') }}

--- a/.github/workflows/publish-typist-package-release.yml
+++ b/.github/workflows/publish-typist-package-release.yml
@@ -49,7 +49,7 @@ jobs:
                   node-version-file: .node-version
 
             - name: Cache project 'node_modules' directory
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               id: node-modules-cache
               with:
                   key: node-modules-cache-${{ hashFiles('**/package-lock.json', '**/.node-version') }}


### PR DESCRIPTION
It moves away from unsupported nodejs version to `node20`

See https://github.com/actions/cache?tab=readme-ov-file#v4

For https://github.com/Doist/platform-backlog/issues/628
