### PR TITLE
fix: Check table element before pasting it as a string

### DIFF
--- a/src/extensions/shared/paste-html-table-as-string.ts
+++ b/src/extensions/shared/paste-html-table-as-string.ts
@@ -35,13 +35,13 @@ const PasteHTMLTableAsString = Extension.create({
 
                         // Concatenate all tables into a single string of paragraphs
                         return tableHTML.reduce((result, table) => {
-                            const { firstElementChild: tableElement } = parseHtmlToElement(
-                                table,
-                            ) as {
-                                firstElementChild: HTMLTableElement | null
-                            }
+                            const { firstElementChild: tableElement } = parseHtmlToElement(table)
 
-                            if (!tableElement) {
+                            if (
+                                !tableElement ||
+                                !(tableElement instanceof HTMLTableElement) ||
+                                !tableElement.rows
+                            ) {
                                 return result
                             }
 


### PR DESCRIPTION
## Overview

We're getting this error in Sentry, pointed to this library. 

```
TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
```

The stack trace points to the line that calls `Array.from(tableElement.rows)`.

## PR Checklist

<!-- Feel free to remove the lines that are not applicable or leave them unchecked. -->

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
-   [ ] Added/updated unit test cases and/or end-to-end test cases
-   [ ] Added/updated documentation to Storybook or `README.md`

## Test plan

We do not know how to reproduce this. But hopefully the changes make sense.

Part of the key to accept these changes is the removal of the type coercion on the return value of `parseHtmlToElement`. It is safer to not do that, and then check that the returned element is an instance of `HTMLTableElement`. On top of that, as an extra check, I added the condition to check that `tableElement.rows` is not a falsy value.