### PR TITLE
fix(rich-text-code): Retore original Tiptap input/paste rules

### DIFF
--- a/src/extensions/rich-text/rich-text-code.ts
+++ b/src/extensions/rich-text/rich-text-code.ts
@@ -1,3 +1,4 @@
+import { markInputRule, markPasteRule } from '@tiptap/core'
 import { Code } from '@tiptap/extension-code'
 
 import { CODE_EXTENSION_PRIORITY } from '../../constants/extension-priorities'
@@ -10,6 +11,18 @@ import type { CodeOptions } from '@tiptap/extension-code'
 type RichTextCodeOptions = CodeOptions
 
 /**
+ * The original input regex for Markdown inline code (i.e. `<code>code</code>`) to prevent the issue
+ * introduced in this PR: https://github.com/ueberdosis/tiptap/pull/4468#issuecomment-2575093998
+ */
+const inputRegex = /(?:^|\s)(`(?!\s+`)((?:[^`]+))`(?!\s+`))$/
+
+/**
+ * The original paste regex for Markdown inline code (i.e. `<code>code</code>`) to prevent the issue
+ * introduced in this PR: https://github.com/ueberdosis/tiptap/pull/4468#issuecomment-2575093998
+ */
+const pasteRegex = /(?:^|\s)(`(?!\s+`)((?:[^`]+))`(?!\s+`))/g
+
+/**
  * Custom extension that extends the built-in `Code` extension to allow all marks (e.g., Bold,
  * Italic, and Strikethrough) to coexist with the `Code` mark (as opposed to disallowing all any
  * other mark by default).
@@ -20,6 +33,22 @@ type RichTextCodeOptions = CodeOptions
 const RichTextCode = Code.extend<RichTextCodeOptions>({
     priority: CODE_EXTENSION_PRIORITY,
     excludes: Code.name,
+    addInputRules() {
+        return [
+            markInputRule({
+                find: inputRegex,
+                type: this.type,
+            }),
+        ]
+    },
+    addPasteRules() {
+        return [
+            markPasteRule({
+                find: pasteRegex,
+                type: this.type,
+            }),
+        ]
+    },
 })
 
 export { RichTextCode }


### PR DESCRIPTION
## Overview

This PR reverts the changes introduced in [this upstream PR](https://github.com/ueberdosis/tiptap/issues/4467), which modified the Markdown shortcut behaviour for inline code marks. Unfortunately, the upstream changes introduced a new bug. By reverting them on the Typist side, we avoid the bug in our products, but this also means the new behaviour will no longer be available. This will help with https://github.com/Doist/Issues/issues/15850.

## PR Checklist

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Type some text, then a space, then open/close back ticks
- Move the cursor to be inside the backticks, and type something
- Move the cursor to the right-side of the paragraph, press space
    - [ ] Observe that nothing happens, and the paragraph looks exactly as before

## Demo

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>

https://github.com/user-attachments/assets/6412e842-0c08-4c6a-91ba-6b801b6e3176

</td><td>

https://github.com/user-attachments/assets/f365f4dd-8697-425f-adf7-b2a7af6246ab

</td></tr>
</tbody>
</table>

