### PR TITLE
fix(html-serializer): Remove support for single tilde syntax for strike-through text

### DIFF
--- a/src/serializers/html/html.test.ts
+++ b/src/serializers/html/html.test.ts
@@ -43,7 +43,8 @@ This text is __*really important*__.
 This text is **_really important_**.
 This is really ***very*** important text.
 
-Strikethrough uses two tildes: ~~scratch this~~`
+Strikethrough uses two tildes: ~~scratch this~~
+Strikethrough with a single tilde: ~not scratched~`
 
 const MARKDOWN_INPUT_BLOCKQUOTES = `> Dorothy followed her through many of the beautiful rooms in her castle.
 
@@ -283,7 +284,7 @@ describe('HTML Serializer', () => {
 
             test('styled text syntax is preserved', () => {
                 expect(htmlSerializer.serialize(MARKDOWN_INPUT_STYLED_TEXT)).toBe(
-                    '<p>I just love **bold text**.</p><p>I just love __bold text__.</p><p></p><p>Italicized text is the *cat&#39;s meow*.</p><p>Italicized text is the _cat&#39;s meow_.</p><p></p><p>This text is ***really important***.</p><p>This text is ___really important___.</p><p>This text is __*really important*__.</p><p>This text is **_really important_**.</p><p>This is really ***very*** important text.</p><p></p><p>Strikethrough uses two tildes: ~~scratch this~~</p>',
+                    '<p>I just love **bold text**.</p><p>I just love __bold text__.</p><p></p><p>Italicized text is the *cat&#39;s meow*.</p><p>Italicized text is the _cat&#39;s meow_.</p><p></p><p>This text is ***really important***.</p><p>This text is ___really important___.</p><p>This text is __*really important*__.</p><p>This text is **_really important_**.</p><p>This is really ***very*** important text.</p><p></p><p>Strikethrough uses two tildes: ~~scratch this~~</p><p>Strikethrough with a single tilde: ~not scratched~</p>',
                 )
             })
 
@@ -417,7 +418,7 @@ Answer: [Doist Frontend](channel://190200)`),
 
             test('styled text HTML output is correct', () => {
                 expect(htmlSerializer.serialize(MARKDOWN_INPUT_STYLED_TEXT)).toBe(
-                    "<p>I just love <strong>bold text</strong>.<br>I just love <strong>bold text</strong>.</p><p>Italicized text is the <em>cat's meow</em>.<br>Italicized text is the <em>cat's meow</em>.</p><p>This text is <em><strong>really important</strong></em>.<br>This text is <em><strong>really important</strong></em>.<br>This text is <strong><em>really important</em></strong>.<br>This text is <strong><em>really important</em></strong>.<br>This is really <em><strong>very</strong></em> important text.</p><p>Strikethrough uses two tildes: <del>scratch this</del></p>",
+                    "<p>I just love <strong>bold text</strong>.<br>I just love <strong>bold text</strong>.</p><p>Italicized text is the <em>cat's meow</em>.<br>Italicized text is the <em>cat's meow</em>.</p><p>This text is <em><strong>really important</strong></em>.<br>This text is <em><strong>really important</strong></em>.<br>This text is <strong><em>really important</em></strong>.<br>This text is <strong><em>really important</em></strong>.<br>This is really <em><strong>very</strong></em> important text.</p><p>Strikethrough uses two tildes: <del>scratch this</del><br>Strikethrough with a single tilde: ~not scratched~</p>",
                 )
             })
 
@@ -568,7 +569,8 @@ Italicized text is the _cat's meow_.</p><p>This text is ***really important***.
 This text is ___really important___.
 This text is __*really important*__.
 This text is **_really important_**.
-This is really ***very*** important text.</p><p>Strikethrough uses two tildes: ~~scratch this~~</p>`)
+This is really ***very*** important text.</p><p>Strikethrough uses two tildes: ~~scratch this~~
+Strikethrough with a single tilde: ~not scratched~</p>`)
             })
 
             test('blockquotes HTML output is preserved', () => {

--- a/src/serializers/html/html.ts
+++ b/src/serializers/html/html.ts
@@ -104,7 +104,7 @@ function createHTMLSerializer(schema: Schema): HTMLSerializerReturnType {
     // Configure the unified processor to use a custom plugin to add support for the strikethrough
     // extension from the GitHub Flavored Markdown (GFM) specification
     if (schema.marks.strike) {
-        unifiedProcessor.use(remarkStrikethrough)
+        unifiedProcessor.use(remarkStrikethrough, { singleTilde: false })
     }
 
     // Configure the unified processor to use a custom plugin to add support for the autolink


### PR DESCRIPTION
## Overview

What the title says 👆

The goal is to make sure that the Markdown syntax used by Typist matches the most commonly accepted syntax for strike-through text, given the lack of a proper CommonMark standard. This decision also matches GitHub Flavored Markdown syntax, which is widely accepted.

## PR Checklist

<!-- Feel free to remove the lines that are not applicable or leave them unchecked. -->

-   [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
-   [x] Added/updated unit test cases and/or end-to-end test cases

## Test plan

- Open the preview Storybook deployed to Netlify
- Open the `Rich-text → Default` story
- Type `~strike~` into the `content` control
    - [ ] Observe that the text `~strike~` appears in the editor as-is (not strike-through)