### PR TITLE
ci: Trigger patch releases for chore commits

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -6,7 +6,13 @@
         [
             "@semantic-release/commit-analyzer",
             {
-                "preset": "conventionalcommits"
+                "preset": "conventionalcommits",
+                "releaseRules": [
+                    {
+                        "type": "chore",
+                        "release": "patch"
+                    }
+                ]
             }
         ],
         [


### PR DESCRIPTION
<!-- Thank you for your contribution to the Typist repository. -->

<!-- Please remove all sections that are not relevant. -->

## Overview

We're now triggering automatic patch releases when bumping dependencies (or doing other `chore:` commits).

See https://github.com/semantic-release/commit-analyzer

I'm uncertain whether we'll need to adapt the [@semantic-release/release-notes-generator](https://github.com/semantic-release/release-notes-generator) configuration as well. If we do, we likely need to add all `types` from [`DEFAULT_COMMIT_TYPES`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/src/constants.js) only to change `hidden` to `false` on `chore` commits. Seems like a lot of work, so let's hope this just works™

