### PR TITLE
fix!: add publint and fix package publishing metadata

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,6 +12,7 @@
 # Project output
 dist/
 storybook-static/
+*.tsbuildinfo
 
 # Project dependencies
 node_modules/

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,7 +7,7 @@ module.exports = {
         global: true,
         module: true,
     },
-    ignorePatterns: ['.eslintrc.js', 'lint-staged.config.js', 'release.config.js'],
+    ignorePatterns: ['.eslintrc.cjs', 'lint-staged.config.js', 'release.config.js'],
     plugins: ['unicorn'],
     extends: [
         '@doist/eslint-config/recommended-type-checked',

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Project output
 dist/
 storybook-static/
+*.tsbuildinfo
 
 # Project dependencies
 node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,7 @@
 # Project output
 dist/
 storybook-static/
+*.tsbuildinfo
 
 # Project dependencies
 node_modules/

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,6 +1,6 @@
-const doistPrettierConfig = require('@doist/prettier-config')
+import doistPrettierConfig from '@doist/prettier-config' with { type: 'json' }
 
-module.exports = {
+export default {
     ...doistPrettierConfig,
     overrides: [
         {

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     './**/*.{js,jsx,ts,tsx}': 'eslint --cache --cache-location ./.cache/.eslintcache --fix',
     './**/*.{json,css,yml,md}': 'prettier --write',
     './**/.{html,svg}': 'prettier --parser html --write',

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
                 "lint-staged": "16.3.2",
                 "npm-run-all-next": "1.2.3",
                 "prettier": "3.8.1",
+                "publint": "0.3.18",
                 "react": "18.3.1",
                 "react-dom": "18.3.1",
                 "react-icons": "5.6.0",
@@ -201,8 +202,7 @@
             "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.18.tgz",
             "integrity": "sha512-9urEa+GbZTSyredq3B/3thQjTcSZSUC68XctwCkJNH/xNfKN5O+VThiem2rcJxpsGw8sRUQenhagZi0yB4foyg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@ariakit/react": {
             "version": "0.4.21",
@@ -229,7 +229,6 @@
             "integrity": "sha512-rUI9uB/gT3mROFja/ka7/JukkdljIZR3eq3BGiQqX4Ni/KBMDvPK8FvVLnC0TGzWcqNY2bbfve8QllvHzuw4fQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ariakit/core": "0.4.18",
                 "@floating-ui/dom": "^1.0.0",
@@ -326,6 +325,7 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -813,6 +813,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -853,6 +854,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             }
@@ -1881,7 +1883,6 @@
             "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@floating-ui/utils": "^0.2.10"
             }
@@ -1892,7 +1893,6 @@
             "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@floating-ui/core": "^1.7.4",
                 "@floating-ui/utils": "^0.2.10"
@@ -1903,8 +1903,7 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
             "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.13.0",
@@ -2060,8 +2059,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
             "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
-            "license": "BSD-2-Clause",
-            "peer": true
+            "license": "BSD-2-Clause"
         },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "0.2.12",
@@ -2140,6 +2138,7 @@
             "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^6.0.0",
                 "@octokit/graphql": "^9.0.3",
@@ -2596,7 +2595,6 @@
             "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
             },
@@ -2657,6 +2655,19 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
+            }
+        },
+        "node_modules/@publint/pack": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/@publint/pack/-/pack-0.1.4.tgz",
+            "integrity": "sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://bjornlu.com/sponsor"
             }
         },
         "node_modules/@remirror/core-constants": {
@@ -3050,8 +3061,7 @@
             "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
             "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@sec-ant/readable-stream": {
             "version": "0.4.1",
@@ -3906,6 +3916,7 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -3994,6 +4005,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.2.tgz",
             "integrity": "sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -4404,6 +4416,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.2.tgz",
             "integrity": "sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prosemirror-changeset": "^2.3.0",
                 "prosemirror-collab": "^1.3.1",
@@ -4594,8 +4607,7 @@
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/linkify-it": {
             "version": "5.0.0",
@@ -4705,6 +4717,7 @@
             "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -4716,6 +4729,7 @@
             "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^18.0.0"
             }
@@ -4875,7 +4889,6 @@
             "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/types": "8.56.0",
                 "@typescript-eslint/typescript-estree": "8.56.0",
@@ -5448,6 +5461,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5621,7 +5635,6 @@
             "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.4",
@@ -5655,7 +5668,6 @@
             "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
@@ -5677,7 +5689,6 @@
             "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.4",
@@ -5700,7 +5711,6 @@
             "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "define-properties": "^1.2.1",
@@ -5720,7 +5730,6 @@
             "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "define-properties": "^1.2.1",
@@ -5740,7 +5749,6 @@
             "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
@@ -5967,6 +5975,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -6233,7 +6242,8 @@
             "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
             "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/clean-regexp": {
             "version": "1.0.0",
@@ -7739,7 +7749,6 @@
             "integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.4",
@@ -7804,7 +7813,6 @@
             "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "hasown": "^2.0.2"
             },
@@ -7837,6 +7845,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -7901,6 +7910,7 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -7957,6 +7967,7 @@
             "integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -7997,7 +8008,6 @@
             "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "debug": "^3.2.7",
                 "is-core-module": "^2.13.0",
@@ -8010,7 +8020,6 @@
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -8056,7 +8065,6 @@
             "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "debug": "^3.2.7"
             },
@@ -8075,7 +8083,6 @@
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -8121,7 +8128,6 @@
             "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8133,7 +8139,6 @@
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -8144,7 +8149,6 @@
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "esutils": "^2.0.2"
             },
@@ -8158,7 +8162,6 @@
             "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "minimist": "^1.2.0"
             },
@@ -8172,7 +8175,6 @@
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -8186,7 +8188,6 @@
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -8197,7 +8198,6 @@
             "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/json5": "^0.0.29",
                 "json5": "^1.0.2",
@@ -8243,7 +8243,6 @@
             "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "array-includes": "^3.1.8",
                 "array.prototype.findlast": "^1.2.5",
@@ -8298,7 +8297,6 @@
             "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8310,7 +8308,6 @@
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "esutils": "^2.0.2"
             },
@@ -8324,7 +8321,6 @@
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -8338,7 +8334,6 @@
             "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "is-core-module": "^2.16.1",
@@ -8363,7 +8358,6 @@
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -8374,6 +8368,7 @@
             "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "eslint": ">=5.0.0"
             }
@@ -8912,8 +8907,7 @@
             "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
             "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
             "dev": true,
-            "license": "Apache-2.0",
-            "peer": true
+            "license": "Apache-2.0"
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
@@ -9809,7 +9803,6 @@
             "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
             "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "hast-util-is-element": "^3.0.0"
@@ -9824,7 +9817,6 @@
             "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
             "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "devlop": "^1.1.0",
@@ -9843,7 +9835,6 @@
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
             "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "entities": "^6.0.0"
             },
@@ -9890,7 +9881,6 @@
             "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
             "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "hast-util-embedded": "^3.0.0",
@@ -9960,7 +9950,6 @@
             "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
             "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "@types/unist": "^3.0.0",
@@ -10062,8 +10051,7 @@
             "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
             "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/hermes-parser": {
             "version": "0.25.1",
@@ -10071,7 +10059,6 @@
             "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "hermes-estree": "0.25.1"
             }
@@ -10282,7 +10269,6 @@
             "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -11183,7 +11169,6 @@
             "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "define-data-property": "^1.1.4",
                 "es-object-atoms": "^1.0.0",
@@ -11231,6 +11216,7 @@
             "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@acemir/cssom": "^0.9.31",
                 "@asamuzakjp/dom-selector": "^6.8.1",
@@ -11346,7 +11332,6 @@
             "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "array-includes": "^3.1.6",
                 "array.prototype.flat": "^1.3.1",
@@ -11463,7 +11448,8 @@
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
             "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lint-staged": {
             "version": "16.3.2",
@@ -11626,7 +11612,8 @@
             "version": "4.17.23",
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
             "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
@@ -11963,6 +11950,7 @@
             "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "marked": "bin/marked.js"
             },
@@ -12122,6 +12110,7 @@
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
             "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "ccount": "^2.0.0",
@@ -12157,6 +12146,7 @@
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
             "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "mdast-util-from-markdown": "^2.0.0",
@@ -12270,7 +12260,6 @@
             "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
             "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "mdast-util-find-and-replace": "^3.0.0"
@@ -12487,6 +12476,7 @@
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
             "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-sanitize-uri": "^2.0.0",
@@ -12524,6 +12514,7 @@
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
             "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-util-chunked": "^2.0.0",
@@ -13095,6 +13086,16 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
+        "node_modules/mri": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -13224,7 +13225,6 @@
             "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "array.prototype.flatmap": "^1.3.3",
                 "es-errors": "^1.3.0",
@@ -13244,7 +13244,6 @@
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -15371,6 +15370,7 @@
             "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -15563,7 +15563,6 @@
             "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.4",
@@ -15580,7 +15579,6 @@
             "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
@@ -15600,7 +15598,6 @@
             "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
@@ -15616,7 +15613,6 @@
             "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.3",
@@ -15843,6 +15839,13 @@
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "dev": true,
             "license": "BlueOak-1.0.0"
+        },
+        "node_modules/package-manager-detector": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+            "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
@@ -16418,6 +16421,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -16551,6 +16555,7 @@
             "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -16567,7 +16572,6 @@
             "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-diff": "^1.1.2"
             },
@@ -16746,6 +16750,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
             "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prosemirror-state": "^1.0.0",
                 "prosemirror-transform": "^1.0.0"
@@ -16789,6 +16794,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
             "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "orderedmap": "^2.0.0"
             }
@@ -16818,6 +16824,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
             "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.0.0",
                 "prosemirror-transform": "^1.0.0",
@@ -16866,6 +16873,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.6.tgz",
             "integrity": "sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.20.0",
                 "prosemirror-state": "^1.0.0",
@@ -16893,6 +16901,28 @@
             "dev": true,
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/publint": {
+            "version": "0.3.18",
+            "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.18.tgz",
+            "integrity": "sha512-JRJFeBTrfx4qLwEuGFPk+haJOJN97KnPuK01yj+4k/Wj5BgoOK5uNsivporiqBjk2JDaslg7qJOhGRnpltGeog==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@publint/pack": "^0.1.4",
+                "package-manager-detector": "^1.6.0",
+                "picocolors": "^1.1.1",
+                "sade": "^1.8.1"
+            },
+            "bin": {
+                "publint": "src/cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://bjornlu.com/sponsor"
+            }
         },
         "node_modules/punycode": {
             "version": "2.3.1",
@@ -16976,6 +17006,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -17057,6 +17088,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -17660,7 +17692,6 @@
             "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
             "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "hast-util-from-html": "^2.0.0",
@@ -17760,6 +17791,7 @@
             "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
             "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "mdast-util-from-markdown": "^2.0.0",
@@ -17776,6 +17808,7 @@
             "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
             "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "@types/mdast": "^4.0.0",
@@ -17942,6 +17975,7 @@
             "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -18022,6 +18056,19 @@
             "license": "MIT",
             "dependencies": {
                 "queue-microtask": "^1.2.2"
+            }
+        },
+        "node_modules/sade": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+            "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mri": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/safe-array-concat": {
@@ -18154,6 +18201,7 @@
             "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@semantic-release/commit-analyzer": "^13.0.1",
                 "@semantic-release/error": "^4.0.0",
@@ -18809,6 +18857,7 @@
             "integrity": "sha512-Az1Qro0XjCBttsuO55H2aIGPYqGx00T8O3o29rLQswOyZhgAVY9H2EnJiVsfmSG1Kwt8qYTVv7VxzLlqDxropA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@storybook/global": "^5.0.0",
                 "@storybook/icons": "^2.0.1",
@@ -18905,7 +18954,6 @@
             "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.3",
@@ -18953,7 +19001,6 @@
             "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.5"
@@ -19288,7 +19335,6 @@
             "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@pkgr/core": "^0.2.9"
             },
@@ -19787,6 +19833,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -19902,6 +19949,7 @@
             "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
             "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "bail": "^2.0.0",
@@ -19937,6 +19985,7 @@
             "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
             "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/unist": "^3.0.0"
             },
@@ -19992,6 +20041,7 @@
             "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
             "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "unist-util-is": "^6.0.0",
@@ -20255,6 +20305,7 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -20330,6 +20381,7 @@
             "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.0.18",
                 "@vitest/mocker": "4.0.18",
@@ -20957,7 +21009,6 @@
             "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     ],
     "scripts": {
         "build": "run-s clean:* build:typist",
+        "postbuild": "publint",
         "build:storybook": "storybook build",
         "build:typist": "tsc --build tsconfig.build.json",
         "check": "run-p check:* -c -l -t",
@@ -121,6 +122,7 @@
         "lint-staged": "16.3.2",
         "npm-run-all-next": "1.2.3",
         "prettier": "3.8.1",
+        "publint": "0.3.18",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-icons": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
     "version": "9.0.3",
     "license": "MIT",
     "homepage": "https://typist.doist.dev/",
-    "repository": "https://github.com/Doist/typist",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Doist/typist.git"
+    },
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "type": "git",
         "url": "git+https://github.com/Doist/typist.git"
     },
+    "type": "module",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -11,6 +11,12 @@
     "type": "module",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
     "sideEffects": false,
     "engines": {
         "node": "^22.14.0 || >= 24.10.0",

--- a/release.config.js
+++ b/release.config.js
@@ -1,7 +1,7 @@
 /**
  * @type {import('semantic-release').GlobalConfig}
  */
-module.exports = {
+export default {
     branches: ['main', { name: 'next', prerelease: true }],
     plugins: [
         [


### PR DESCRIPTION
## Overview

Set up [publint](https://publint.dev/) to lint package publishing metadata and fix all reported issues:

- **Added `publint` as a devDependency** with a `postbuild` hook so it runs automatically after every build (locally and in CI)
- **Fixed `repository` field** to use the canonical object format with `git+https://` URL scheme
- **Added `"type": "module"`** to correctly declare the package as ESM (the build output was already ESM syntax but was being misinterpreted as CJS)
- **Converted config files to ESM** (`.prettierrc.js`, `lint-staged.config.js`, `release.config.js`), renamed `.eslintrc.js` to `.eslintrc.cjs` (ESLint 8 doesn't support ESM in legacy config)
- **Added `exports` field** for modern entry point declaration
- **Added `*.tsbuildinfo` to `.gitignore`**

### Breaking Changes

- `"type": "module"` changes the module resolution contract — consumers using `require('@doist/typist')` would no longer work (though this was already broken in practice since the output was ESM syntax)
- The `exports` field restricts deep imports (e.g., `@doist/typist/dist/...`). Verified that todoist-web has no deep imports. twist-web has one legacy deep import but is on an older version and the symbol is already available from the main export.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- [x] `npx publint` reports "All good!" after build
- [x] All 129 unit tests pass
- [x] Prettier config loads correctly
- [x] ESLint config loads correctly
- [x] lint-staged config loads correctly
- [x] semantic-release config loads correctly (verified via `--dry-run`)
- [x] CI passes on this PR
- [x] After merge to `next`, verify pre-release version is published to npm `@next` dist-tag