### PR TITLE
docs: remove redundant post-release sync step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,14 +86,6 @@ To test features before publishing a stable release:
 
 4. **Promote to stable:** When ready, open a PR to merge `next` into `main`. The PR title must follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat: ...`, `fix: ...`) as it determines the version bump for the stable release.
 
-5. **Sync `next` with `main`** after the stable release, to pull back the release commit:
-
-    ```sh
-    git checkout next
-    git merge main -m "chore: sync next with main [skip ci]"
-    git push origin next
-    ```
-
 > **Note:** The `CHANGELOG.md` is only updated for stable releases on `main`. Pre-releases still get GitHub release notes and npm publication.
 
 ### Visual Studio Code


### PR DESCRIPTION
## Overview

Removes the "sync `next` with `main` after the stable release" step (step 5) from the pre-release workflow in CONTRIBUTING.md.

Step 1 already handles syncing before starting new work on `next`, making the post-release sync redundant — by the time anyone uses `next` again, `main` will have moved ahead with unrelated merges anyway.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Read through the pre-release workflow in CONTRIBUTING.md
    - [ ] Observe that the steps still read clearly without the removed step