### PR TITLE
docs: address post-merge review feedback on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ The release process for Typist is fully automated with [`semantic-release`](http
 
 To test features before publishing a stable release:
 
-1. **Sync `next` with `main`** if they are out of sync, before starting new work:
+1. **Sync `next` with `main`** before starting new work, and after each stable release (required for `semantic-release` to correctly initiate the next pre-release versioning cycle):
 
     ```sh
     git checkout next
@@ -138,7 +138,7 @@ A commit that has the text `BREAKING CHANGE:` at the beginning of its optional b
 
 #### How Commits Map to the CHANGELOG
 
-Only the commit **header** (subject line) and `BREAKING CHANGE:` **footer** are used to generate the `CHANGELOG.md`. The commit body is ignored by the changelog generator.
+Only the commit **header** (subject line) and `BREAKING CHANGE:` notes (whether in the body or footer) are used to generate the `CHANGELOG.md`. The rest of the commit body is ignored by the changelog generator.
 
 When squash-merging a PR, GitHub lets you edit the commit message and extended description. Keep the following in mind:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ A commit that has the text `BREAKING CHANGE:` at the beginning of its optional b
 
 #### How Commits Map to the CHANGELOG
 
-Only the commit **header** (subject line) and `BREAKING CHANGE:` notes (whether in the body or footer) are used to generate the `CHANGELOG.md`. The rest of the commit body is ignored by the changelog generator.
+The commit **header** (subject line) and footer metadata — including `BREAKING CHANGE:` notes and issue references (e.g., `Closes #123`) — are used to generate the `CHANGELOG.md`. The commit body is ignored by the changelog generator.
 
 When squash-merging a PR, GitHub lets you edit the commit message and extended description. Keep the following in mind:
 


### PR DESCRIPTION
## Overview

Addresses reviewer comments that were raised after their respective PRs were already merged:

- **#1256**: The note "The commit body is ignored by the changelog generator" was misleading — `BREAKING CHANGE:` notes are still parsed when they appear in the body, and issue references from footers (e.g., `Closes #123`) are also preserved. Rewrote the opening sentence to accurately describe what gets included.
- **#1257**: The reviewer warned that removing the post-release sync step could disrupt `semantic-release`, which relies on `next` being synced with `main` after a stable release. Broadened step 1 to explicitly cover this case, instead of restoring the removed step.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
- [x] Added/updated documentation to `CONTRIBUTING.md`

## Test plan

- Read through the updated sections in `CONTRIBUTING.md`
    - [ ] Observe that the "How Commits Map to the CHANGELOG" section now correctly describes which parts of the commit message are used (header, `BREAKING CHANGE:` notes, and other footer metadata like issue references)
    - [ ] Observe that step 1 of the pre-release workflow now mentions syncing after stable releases