### PR TITLE
docs: add docs/README.md index for AI agent navigation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+# Typist Documentation
+
+## React Guidelines
+
+- [react-guidelines/async.md](react-guidelines/async.md) - Async patterns including race condition handling with AbortController and effect cleanup
+- [react-guidelines/conventions.md](react-guidelines/conventions.md) - JSX conventions, component patterns, and rendering best practices
+- [react-guidelines/react-compiler.md](react-guidelines/react-compiler.md) - React Compiler adoption, when to remove manual memoization, and known edge cases
+- [react-guidelines/state.md](react-guidelines/state.md) - State management guidance for Redux Toolkit, Zustand, React state, and React Router
+- [react-guidelines/testing.md](react-guidelines/testing.md) - Component testing with React Testing Library and userEvent
+
+## TypeScript Guidelines
+
+- [typescript-guidelines/async.md](typescript-guidelines/async.md) - Promise handling, async/await patterns, and error handling for async code
+- [typescript-guidelines/conventions.md](typescript-guidelines/conventions.md) - Naming conventions, function style, and code organization
+- [typescript-guidelines/errors.md](typescript-guidelines/errors.md) - Error handling with unknown catch parameters, type narrowing, and suppression rules
+- [typescript-guidelines/philosophy.md](typescript-guidelines/philosophy.md) - Core principles: strict types, simplicity, self-documenting code, and accessibility
+- [typescript-guidelines/testing.md](typescript-guidelines/testing.md) - Testing strategy, file naming, and test organization across unit, component, hook, and integration tests
+- [typescript-guidelines/types.md](typescript-guidelines/types.md) - Type system usage: interfaces vs types, extending interfaces, and union types


### PR DESCRIPTION
## Overview

Add a `docs/README.md` index file for AI agents (as referenced by `AGENTS.md`) to navigate the documentation. It covers all files in `docs/react-guidelines/` and `docs/typescript-guidelines/` with a brief, accurate description for each.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
- [x] Added/updated documentation to Storybook or `README.md`

## Test plan

- Open [docs/README.md](docs/README.md) and verify:
    - [x] All links match the actual files in `docs/react-guidelines/` and `docs/typescript-guidelines/`
    - [x] Each description accurately reflects the file contents