### PR TITLE
chore: add CODEOWNERS file for automatic PR review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Designated Responsible Developer (DRD) for this project.
+# Automatically requested for review on every pull request.
+* @rfgamaral


### PR DESCRIPTION
## Overview

Add a `CODEOWNERS` file to automatically request a review from the project's Designated Responsible Developer (DRD) on every pull request.

This follows the same convention used by other Doist repositories (e.g., `todoist-api-python`, `ticki_quick_docs`) by placing the file in `.github/CODEOWNERS`.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)