### PR TITLE
ci: improve release workflow and CI validation

### DIFF
--- a/.github/workflows/check-ci-validation.yml
+++ b/.github/workflows/check-ci-validation.yml
@@ -5,10 +5,14 @@ on:
     pull_request:
         types:
             - opened
+            - reopened
             - synchronize
 
-env:
-    GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+# Restrict permissions to read-only since validation jobs only need to checkout
+# and analyse the code. This limits the blast radius when called from workflows
+# that have broader permissions (e.g., the release workflow).
+permissions:
+    contents: read
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,7 +22,7 @@ jobs:
     prepare-workflow:
         name: Prepare Workflow
         runs-on: ubuntu-latest
-        timeout-minutes: 60
+        timeout-minutes: 15
 
         steps:
             - name: Checkout repository
@@ -45,7 +49,7 @@ jobs:
     static-code-analysis:
         name: Static Code Analysis
         runs-on: ubuntu-latest
-        timeout-minutes: 60
+        timeout-minutes: 15
 
         needs:
             - prepare-workflow
@@ -87,7 +91,7 @@ jobs:
     unit-testing:
         name: Unit Testing
         runs-on: ubuntu-latest
-        timeout-minutes: 60
+        timeout-minutes: 15
 
         needs:
             - prepare-workflow
@@ -114,14 +118,14 @@ jobs:
               run: |
                   npm ci
 
-            - name: Test codebase correctnesss
+            - name: Test codebase correctness
               run: |
                   npm run test
 
     build-package:
         name: Build Package
         runs-on: ubuntu-latest
-        timeout-minutes: 60
+        timeout-minutes: 15
 
         needs:
             - prepare-workflow

--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -14,7 +14,7 @@ permissions:
     id-token: write
     # Enable the use of GitHub Packages registry
     packages: write
-    # Enable `semantic-release` to publish a GitHub release
+    # Enable `semantic-release` to publish a GitHub release and push commits
     contents: write
     # Enable `semantic-release` to post comments on issues
     issues: write
@@ -32,20 +32,29 @@ jobs:
     ci-validation:
         name: CI Validation
         uses: ./.github/workflows/check-ci-validation.yml
-        secrets: inherit
 
     release-and-publish:
         name: Release & Publish
         runs-on: ubuntu-latest
-        timeout-minutes: 60
+        timeout-minutes: 30
 
         needs: ci-validation
 
         steps:
+            - name: Generate release bot token
+              id: release-bot
+              uses: actions/create-github-app-token@v3
+              with:
+                  app-id: ${{ secrets.DOIST_RELEASE_BOT_ID }}
+                  private-key: ${{ secrets.DOIST_RELEASE_BOT_PRIVATE_KEY }}
+                  permission-contents: write
+                  permission-issues: write
+                  permission-pull-requests: write
+
             - name: Checkout repository
               uses: actions/checkout@v6
               with:
-                  token: ${{ secrets.GH_REPO_TOKEN }}
+                  token: ${{ steps.release-bot.outputs.token }}
                   fetch-depth: 0
 
             - name: Prepare Node.js environment
@@ -80,7 +89,7 @@ jobs:
               run: |
                   npx semantic-release
               env:
-                  GITHUB_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
+                  GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
                   GIT_AUTHOR_EMAIL: doistbot@users.noreply.github.com
                   GIT_AUTHOR_NAME: Doist Bot
                   GIT_COMMITTER_EMAIL: doistbot@users.noreply.github.com
@@ -92,8 +101,8 @@ jobs:
                   npm config delete @doist:registry --location=project
 
             - name: Prepare Node.js environment for GitHub Packages registry
-              uses: actions/setup-node@v6
               if: ${{ steps.semantic-release.outputs.package-published == 'true' }}
+              uses: actions/setup-node@v6
               with:
                   cache: npm
                   node-version-file: .node-version
@@ -101,8 +110,8 @@ jobs:
                   scope: '@doist'
 
             - name: Determine npm dist-tag for GitHub Packages
-              if: ${{ steps.semantic-release.outputs.package-published == 'true' }}
               id: dist-tag
+              if: ${{ steps.semantic-release.outputs.package-published == 'true' }}
               run: |
                   if [[ "${{ github.ref_name }}" == "next" ]]; then
                     echo "tag=next" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -14,12 +14,6 @@ permissions:
     id-token: write
     # Enable the use of GitHub Packages registry
     packages: write
-    # Enable `semantic-release` to publish a GitHub release and push commits
-    contents: write
-    # Enable `semantic-release` to post comments on issues
-    issues: write
-    # Enable `semantic-release` to post comments on pull requests
-    pull-requests: write
 
 # The release workflow involves many crucial steps that once triggered shouldn't be cancelled until
 # finished, otherwise we might end up in an inconsistent state (e.g., published to GitHub Packages

--- a/release.config.js
+++ b/release.config.js
@@ -35,8 +35,10 @@ export default {
         [
             '@semantic-release/exec',
             {
-                verifyConditionsCmd: 'echo "package-published=false" >> $GITHUB_OUTPUT',
-                successCmd: 'echo "package-published=true" >> $GITHUB_OUTPUT',
+                verifyConditionsCmd:
+                    'if [ -n "$GITHUB_OUTPUT" ]; then echo "package-published=false" >> "$GITHUB_OUTPUT"; fi',
+                successCmd:
+                    'if [ -n "$GITHUB_OUTPUT" ]; then echo "package-published=true" >> "$GITHUB_OUTPUT"; fi',
             },
         ],
     ],


### PR DESCRIPTION
## Overview

Aligns Typist's release and CI workflows with the improvements recently made in Reactist ([ref1](https://github.com/Doist/reactist/pull/1031), [ref2](https://github.com/Doist/reactist/pull/1032)), while preserving Typist-specific `next` branch support.

The main change is switching from a user PAT (`GH_REPO_TOKEN`) to a GitHub App token (Doist Release Bot) for the release workflow. This ensures semantic-release can push release commits past branch rulesets on `main`, which was migrated from legacy branch protection rules to rulesets as part of this work.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

The release workflow will be validated on the next push to `main` after merge. The CI validation changes can be verified by checking that this PR's own CI passes.