### PR TITLE
fix: add contents read permission for CI validation workflow

### DIFF
--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -14,6 +14,8 @@ permissions:
     id-token: write
     # Enable the use of GitHub Packages registry
     packages: write
+    # Enable the CI validation workflow to checkout the repository
+    contents: read
 
 # The release workflow involves many crucial steps that once triggered shouldn't be cancelled until
 # finished, otherwise we might end up in an inconsistent state (e.g., published to GitHub Packages


### PR DESCRIPTION
## Overview

Fixes the release workflow failing because the called CI validation workflow requests `contents: read`, which requires the caller to grant at least that permission level. Follow-up to #1291.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

The release workflow should pass after merge. This PR also doubles as the release trigger to validate the full workflow end-to-end (GitHub App token, npm publish, GitHub Packages publish, PR comments).