### PR TITLE
chore: replace husky and lint-staged with lefthook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-npm run validate:pre-commit

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,0 @@
-npm run validate:pre-push

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+pre-commit:
+    jobs:
+        - name: lint
+          run: npm run fix:lint -- {staged_files}
+          glob: '*.{js,jsx,ts,tsx,mts}'
+          stage_fixed: true
+        - name: format
+          run: npm run fix:format -- {staged_files}
+          glob: '*.{js,jsx,ts,tsx,mts,css,json,jsonc,md,mdx,yml,yaml,html,svg}'
+          stage_fixed: true
+        - name: typecheck
+          run: npm run check:types
+
+pre-push:
+    jobs:
+        - name: test
+          run: npm run test

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,6 +1,0 @@
-export default {
-    './**/*.{js,jsx,ts,tsx,mts,css,json,jsonc,md,yml,yaml,html,svg}': [
-        'oxfmt --no-error-on-unmatched-pattern',
-    ],
-    './**/*.{js,jsx,ts,tsx,mts}': ['oxlint --fix'],
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,10 +67,8 @@
                 "conventional-changelog-conventionalcommits": "9.3.1",
                 "emoji-regex": "10.6.0",
                 "github-markdown-css": "5.9.0",
-                "husky": "9.1.7",
-                "is-ci": "4.1.0",
                 "jsdom": "29.0.2",
-                "lint-staged": "16.4.0",
+                "lefthook": "2.1.6",
                 "npm-run-all-next": "1.3.0",
                 "oxfmt": "0.36.0",
                 "oxlint": "1.50.0",
@@ -3225,6 +3223,381 @@
                 }
             }
         },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+            "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+            "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+            "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+            "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+            "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+            "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+            "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+            "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+            "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+            "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+            "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+            "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+            "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+            "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+            "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+            "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+            "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+            "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+            "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+            "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+            "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+            "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+            "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+            "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+            "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true
+        },
         "node_modules/@sec-ant/readable-stream": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -5566,29 +5939,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/brace-expansion/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
         "node_modules/braces": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -5864,22 +6214,6 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
-        "node_modules/ci-info": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/sibiraj-s"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/classnames": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
@@ -5895,22 +6229,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/cli-cursor": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "restore-cursor": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cli-highlight": {
@@ -6081,69 +6399,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/cli-truncate": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
-            "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "slice-ansi": "^7.1.0",
-                "string-width": "^8.0.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-truncate/node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/cli-truncate/node_modules/string-width": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-            "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-east-asian-width": "^1.5.0",
-                "strip-ansi": "^7.1.2"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-truncate/node_modules/strip-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
         "node_modules/cliui": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -6257,13 +6512,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/colorette": {
-            "version": "2.0.20",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/comma-separated-tokens": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -6272,16 +6520,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/commander": {
-            "version": "14.0.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
             }
         },
         "node_modules/compare-func": {
@@ -7479,13 +7717,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/eventemitter3": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/execa": {
             "version": "9.6.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
@@ -7961,6 +8192,45 @@
                 "minimatch": "^10.2.1",
                 "minipass": "^7.1.2",
                 "path-scurry": "^2.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/glob/node_modules/balanced-match": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+            "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/glob/node_modules/brace-expansion": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+            "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
+            "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.2"
             },
             "engines": {
                 "node": "20 || >=22"
@@ -8539,22 +8809,6 @@
                 "node": ">=18.18.0"
             }
         },
-        "node_modules/husky": {
-            "version": "9.1.7",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-            "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "husky": "bin.js"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/typicode"
-            }
-        },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -8887,25 +9141,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-ci": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-4.1.0.tgz",
-            "integrity": "sha512-Ab9bQDQ11lWootZUI5qxgN2ZXwxNI5hTwnsvOc1wyxQ7zQ8OkEDw79mI0+9jI3x432NfwbVRru+3noJfXF6lSQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/sibiraj-s"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "ci-info": "^4.1.0"
-            },
-            "bin": {
-                "is-ci": "bin.js"
-            }
-        },
         "node_modules/is-core-module": {
             "version": "2.16.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -9009,22 +9244,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-fullwidth-code-point": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-            "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-east-asian-width": "^1.3.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-generator-function": {
@@ -9554,6 +9773,169 @@
                 "graceful-fs": "^4.1.11"
             }
         },
+        "node_modules/lefthook": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.6.tgz",
+            "integrity": "sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "lefthook": "bin/index.js"
+            },
+            "optionalDependencies": {
+                "lefthook-darwin-arm64": "2.1.6",
+                "lefthook-darwin-x64": "2.1.6",
+                "lefthook-freebsd-arm64": "2.1.6",
+                "lefthook-freebsd-x64": "2.1.6",
+                "lefthook-linux-arm64": "2.1.6",
+                "lefthook-linux-x64": "2.1.6",
+                "lefthook-openbsd-arm64": "2.1.6",
+                "lefthook-openbsd-x64": "2.1.6",
+                "lefthook-windows-arm64": "2.1.6",
+                "lefthook-windows-x64": "2.1.6"
+            }
+        },
+        "node_modules/lefthook-darwin-arm64": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.6.tgz",
+            "integrity": "sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/lefthook-darwin-x64": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.6.tgz",
+            "integrity": "sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/lefthook-freebsd-arm64": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.6.tgz",
+            "integrity": "sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/lefthook-freebsd-x64": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.6.tgz",
+            "integrity": "sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/lefthook-linux-arm64": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.6.tgz",
+            "integrity": "sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/lefthook-linux-x64": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.6.tgz",
+            "integrity": "sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/lefthook-openbsd-arm64": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.6.tgz",
+            "integrity": "sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/lefthook-openbsd-x64": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.6.tgz",
+            "integrity": "sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/lefthook-windows-arm64": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.6.tgz",
+            "integrity": "sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/lefthook-windows-x64": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.6.tgz",
+            "integrity": "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/less": {
             "version": "4.5.1",
             "resolved": "https://registry.npmjs.org/less/-/less-4.5.1.tgz",
@@ -9889,126 +10271,6 @@
             "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
             "license": "MIT"
         },
-        "node_modules/lint-staged": {
-            "version": "16.4.0",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
-            "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "commander": "^14.0.3",
-                "listr2": "^9.0.5",
-                "picomatch": "^4.0.3",
-                "string-argv": "^0.3.2",
-                "tinyexec": "^1.0.4",
-                "yaml": "^2.8.2"
-            },
-            "bin": {
-                "lint-staged": "bin/lint-staged.js"
-            },
-            "engines": {
-                "node": ">=20.17"
-            },
-            "funding": {
-                "url": "https://opencollective.com/lint-staged"
-            }
-        },
-        "node_modules/listr2": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
-            "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cli-truncate": "^5.0.0",
-                "colorette": "^2.0.20",
-                "eventemitter3": "^5.0.1",
-                "log-update": "^6.1.0",
-                "rfdc": "^1.4.1",
-                "wrap-ansi": "^9.0.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/listr2/node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/listr2/node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/listr2/node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/listr2/node_modules/strip-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "node_modules/listr2/node_modules/wrap-ansi": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "string-width": "^7.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
         "node_modules/load-json-file": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -10093,104 +10355,6 @@
             "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/log-update": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
-            "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-escapes": "^7.0.0",
-                "cli-cursor": "^5.0.0",
-                "slice-ansi": "^7.1.0",
-                "strip-ansi": "^7.1.0",
-                "wrap-ansi": "^9.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-update/node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/log-update/node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/log-update/node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-update/node_modules/strip-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "node_modules/log-update/node_modules/wrap-ansi": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "string-width": "^7.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
         },
         "node_modules/longest-streak": {
             "version": "3.1.0",
@@ -11420,19 +11584,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/mimic-function": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/min-indent": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -11441,22 +11592,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "brace-expansion": "^5.0.5"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/minimist": {
@@ -11827,6 +11962,45 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/npm-run-all-next/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/npm-run-all-next/node_modules/brace-expansion": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/npm-run-all-next/node_modules/minimatch": {
+            "version": "10.2.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/npm-run-path": {
@@ -13878,22 +14052,6 @@
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
-            }
-        },
-        "node_modules/onetime": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-function": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/open": {
@@ -15962,30 +16120,6 @@
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
             }
         },
-        "node_modules/restore-cursor": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "onetime": "^7.0.0",
-                "signal-exit": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/rfdc": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/rimraf": {
             "version": "6.1.3",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
@@ -16040,126 +16174,59 @@
                 "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
             }
         },
-        "node_modules/rolldown-plugin-dts": {
-            "version": "0.23.2",
-            "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.23.2.tgz",
-            "integrity": "sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/generator": "8.0.0-rc.3",
-                "@babel/helper-validator-identifier": "8.0.0-rc.3",
-                "@babel/parser": "8.0.0-rc.3",
-                "@babel/types": "8.0.0-rc.3",
-                "ast-kit": "^3.0.0-beta.1",
-                "birpc": "^4.0.0",
-                "dts-resolver": "^2.1.3",
-                "get-tsconfig": "^4.13.7",
-                "obug": "^2.1.1",
-                "picomatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=20.19.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sxzz"
-            },
-            "peerDependencies": {
-                "@ts-macro/tsc": "^0.3.6",
-                "@typescript/native-preview": ">=7.0.0-dev.20260325.1",
-                "rolldown": "^1.0.0-rc.12",
-                "typescript": "^5.0.0 || ^6.0.0",
-                "vue-tsc": "~3.2.0"
-            },
-            "peerDependenciesMeta": {
-                "@ts-macro/tsc": {
-                    "optional": true
-                },
-                "@typescript/native-preview": {
-                    "optional": true
-                },
-                "typescript": {
-                    "optional": true
-                },
-                "vue-tsc": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/rolldown-plugin-dts/node_modules/@babel/generator": {
-            "version": "8.0.0-rc.3",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.3.tgz",
-            "integrity": "sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^8.0.0-rc.3",
-                "@babel/types": "^8.0.0-rc.3",
-                "@jridgewell/gen-mapping": "^0.3.12",
-                "@jridgewell/trace-mapping": "^0.3.28",
-                "@types/jsesc": "^2.5.0",
-                "jsesc": "^3.0.2"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/rolldown-plugin-dts/node_modules/@babel/helper-string-parser": {
-            "version": "8.0.0-rc.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.3.tgz",
-            "integrity": "sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/rolldown-plugin-dts/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.0-rc.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.3.tgz",
-            "integrity": "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/rolldown-plugin-dts/node_modules/@babel/parser": {
-            "version": "8.0.0-rc.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.3.tgz",
-            "integrity": "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^8.0.0-rc.3"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/rolldown-plugin-dts/node_modules/@babel/types": {
-            "version": "8.0.0-rc.3",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.3.tgz",
-            "integrity": "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^8.0.0-rc.3",
-                "@babel/helper-validator-identifier": "^8.0.0-rc.3"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
         "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
             "version": "1.0.0-rc.16",
             "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
             "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/rollup": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+            "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@types/estree": "1.0.8"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.57.1",
+                "@rollup/rollup-android-arm64": "4.57.1",
+                "@rollup/rollup-darwin-arm64": "4.57.1",
+                "@rollup/rollup-darwin-x64": "4.57.1",
+                "@rollup/rollup-freebsd-arm64": "4.57.1",
+                "@rollup/rollup-freebsd-x64": "4.57.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+                "@rollup/rollup-linux-arm64-musl": "4.57.1",
+                "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+                "@rollup/rollup-linux-loong64-musl": "4.57.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+                "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+                "@rollup/rollup-linux-x64-gnu": "4.57.1",
+                "@rollup/rollup-linux-x64-musl": "4.57.1",
+                "@rollup/rollup-openbsd-x64": "4.57.1",
+                "@rollup/rollup-openharmony-arm64": "4.57.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+                "@rollup/rollup-win32-x64-gnu": "4.57.1",
+                "@rollup/rollup-win32-x64-msvc": "4.57.1",
+                "fsevents": "~2.3.2"
+            }
         },
         "node_modules/rope-sequence": {
             "version": "1.3.4",
@@ -16824,36 +16891,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/slice-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-            "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "is-fullwidth-code-point": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-            }
-        },
-        "node_modules/slice-ansi/node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -17050,16 +17087,6 @@
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/string-argv": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
-            "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.6.19"
             }
         },
         "node_modules/string.prototype.padend": {
@@ -17795,6 +17822,74 @@
                 }
             }
         },
+        "node_modules/tsdown/node_modules/@babel/generator": {
+            "version": "8.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.3.tgz",
+            "integrity": "sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^8.0.0-rc.3",
+                "@babel/types": "^8.0.0-rc.3",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "@types/jsesc": "^2.5.0",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/tsdown/node_modules/@babel/helper-string-parser": {
+            "version": "8.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.3.tgz",
+            "integrity": "sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/tsdown/node_modules/@babel/helper-validator-identifier": {
+            "version": "8.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.3.tgz",
+            "integrity": "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/tsdown/node_modules/@babel/parser": {
+            "version": "8.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.3.tgz",
+            "integrity": "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^8.0.0-rc.3"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/tsdown/node_modules/@babel/types": {
+            "version": "8.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.3.tgz",
+            "integrity": "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^8.0.0-rc.3",
+                "@babel/helper-validator-identifier": "^8.0.0-rc.3"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
         "node_modules/tsdown/node_modules/@oxc-project/types": {
             "version": "0.124.0",
             "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
@@ -17898,9 +17993,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17918,9 +18010,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17938,9 +18027,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17958,9 +18044,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17978,9 +18061,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17998,9 +18078,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -18119,6 +18196,52 @@
                 "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
                 "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
                 "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+            }
+        },
+        "node_modules/tsdown/node_modules/rolldown-plugin-dts": {
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.23.2.tgz",
+            "integrity": "sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/generator": "8.0.0-rc.3",
+                "@babel/helper-validator-identifier": "8.0.0-rc.3",
+                "@babel/parser": "8.0.0-rc.3",
+                "@babel/types": "8.0.0-rc.3",
+                "ast-kit": "^3.0.0-beta.1",
+                "birpc": "^4.0.0",
+                "dts-resolver": "^2.1.3",
+                "get-tsconfig": "^4.13.7",
+                "obug": "^2.1.1",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            },
+            "peerDependencies": {
+                "@ts-macro/tsc": "^0.3.6",
+                "@typescript/native-preview": ">=7.0.0-dev.20260325.1",
+                "rolldown": "^1.0.0-rc.12",
+                "typescript": "^5.0.0 || ^6.0.0",
+                "vue-tsc": "~3.2.0"
+            },
+            "peerDependenciesMeta": {
+                "@ts-macro/tsc": {
+                    "optional": true
+                },
+                "@typescript/native-preview": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                },
+                "vue-tsc": {
+                    "optional": true
+                }
             }
         },
         "node_modules/tslib": {
@@ -19576,6 +19699,8 @@
             "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
             "dev": true,
             "license": "ISC",
+            "optional": true,
+            "peer": true,
             "bin": {
                 "yaml": "bin.mjs"
             },

--- a/package.json
+++ b/package.json
@@ -49,13 +49,11 @@
         "fix": "run-s fix:*",
         "fix:format": "oxfmt",
         "fix:lint": "oxlint --fix",
-        "prepare": "is-ci || husky",
+        "prepare": "lefthook install",
         "start": "run-s clean:* start:storybook",
         "start:storybook": "storybook dev --port 6006 --ci",
         "test": "vitest run",
-        "test:watch": "vitest watch",
-        "validate:pre-commit": "lint-staged",
-        "validate:pre-push": "run-s test"
+        "test:watch": "vitest watch"
     },
     "dependencies": {
         "@tiptap/core": "2.27.2",
@@ -116,10 +114,8 @@
         "conventional-changelog-conventionalcommits": "9.3.1",
         "emoji-regex": "10.6.0",
         "github-markdown-css": "5.9.0",
-        "husky": "9.1.7",
-        "is-ci": "4.1.0",
         "jsdom": "29.0.2",
-        "lint-staged": "16.4.0",
+        "lefthook": "2.1.6",
         "npm-run-all-next": "1.3.0",
         "oxfmt": "0.36.0",
         "oxlint": "1.50.0",


### PR DESCRIPTION
## Overview

Replaces husky + lint-staged with [lefthook](https://github.com/evilmartians/lefthook), a single tool that handles both git hook management and staged-file filtering.

**Removed:** `husky`, `lint-staged`, `is-ci`, `.husky/` directory, `lint-staged.config.js`, `validate:pre-commit` / `validate:pre-push` scripts.

**Added:** `lefthook` + `lefthook.yml` with:
- **pre-commit** (sequential): lint fix → format → typecheck
- **pre-push**: tests

Pre-commit jobs run sequentially (not in parallel) because lint and format both mutate overlapping file types (`*.js/ts*`), so parallel execution could cause racey writes and restaging conflicts.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Run `npm install` on a fresh clone
- Observe that lefthook installs hooks successfully
- Make a change to a `.ts` file, stage it, and commit
    - [ ] Observe that oxlint, oxfmt, and tsc run during pre-commit
- Push the branch
    - [ ] Observe that vitest runs during pre-push