### PR TITLE
fix(serializers): include trigger character in suggestion HTML output

### DIFF
--- a/src/constants/suggestions.ts
+++ b/src/constants/suggestions.ts
@@ -1,0 +1,6 @@
+/**
+ * The default trigger character used by suggestion nodes when one is not explicitly configured.
+ */
+const DEFAULT_SUGGESTION_TRIGGER_CHAR = '@'
+
+export { DEFAULT_SUGGESTION_TRIGGER_CHAR }

--- a/src/factories/create-suggestion-extension.ts
+++ b/src/factories/create-suggestion-extension.ts
@@ -4,6 +4,7 @@ import { Suggestion as TiptapSuggestion } from '@tiptap/suggestion'
 import { camelCase, kebabCase } from 'lodash-es'
 
 import { SUGGESTION_EXTENSION_PRIORITY } from '../constants/extension-priorities'
+import { DEFAULT_SUGGESTION_TRIGGER_CHAR } from '../constants/suggestions'
 import { canInsertNodeAt } from '../utilities/can-insert-node-at'
 import { canInsertSuggestion } from '../utilities/can-insert-suggestion'
 
@@ -187,7 +188,7 @@ function createSuggestionExtension<
         atom: true,
         addOptions() {
             return {
-                triggerChar: '@',
+                triggerChar: DEFAULT_SUGGESTION_TRIGGER_CHAR,
                 // Disable option by default until the following Tiptap issue is fixed:
                 // https://github.com/ueberdosis/tiptap/issues/2159
                 allowSpaces: false,
@@ -201,6 +202,14 @@ function createSuggestionExtension<
                 itemsById: Object.fromEntries(
                     items.map((item) => [String(item[idAttribute]), item]),
                 ),
+            }
+        },
+        // Expose the trigger character in the node spec so it can be read from the schema by
+        // serializers and renderers that need to reconstruct the visible text for a suggestion
+        // (e.g., `@username`, `#channel`), without depending on the editor instance.
+        extendNodeSchema(extension) {
+            return {
+                triggerChar: extension.options.triggerChar,
             }
         },
         addAttributes() {

--- a/src/helpers/serializer.test.ts
+++ b/src/helpers/serializer.test.ts
@@ -3,24 +3,26 @@ import { getSchema } from '@tiptap/core'
 import { RichTextKit } from '../extensions/rich-text/rich-text-kit'
 import { createSuggestionExtension } from '../factories/create-suggestion-extension'
 
-import { buildSuggestionSchemaPartialRegex, extractTagsFromParseRules } from './serializer'
+import { buildSuggestionSchemaInfo, extractTagsFromParseRules } from './serializer'
 
 describe('Helper: Serializer', () => {
-    describe('#buildSuggestionSchemaPartialRegex', () => {
+    describe('#buildSuggestionSchemaInfo', () => {
         test('returns `null` when there are no suggestion nodes in the schema', () => {
-            expect(buildSuggestionSchemaPartialRegex(getSchema([RichTextKit]))).toBeNull()
+            expect(buildSuggestionSchemaInfo(getSchema([RichTextKit]))).toBeNull()
         })
 
-        test('returns a partial regular expression including valid URL schemas', () => {
-            expect(
-                buildSuggestionSchemaPartialRegex(
-                    getSchema([
-                        RichTextKit,
-                        createSuggestionExtension('mention'),
-                        createSuggestionExtension('channel'),
-                    ]),
-                ),
-            ).toBe('(?:mention|channel)://')
+        test('returns the URL scheme regex and trigger character map for available suggestions', () => {
+            const info = buildSuggestionSchemaInfo(
+                getSchema([
+                    RichTextKit,
+                    createSuggestionExtension('mention'),
+                    createSuggestionExtension('channel').configure({ triggerChar: '#' }),
+                ]),
+            )
+
+            expect(info?.urlSchemeRegex).toBe('(?:mention|channel)://')
+            expect(info?.triggerCharByScheme.get('mention')).toBe('@')
+            expect(info?.triggerCharByScheme.get('channel')).toBe('#')
         })
     })
 

--- a/src/helpers/serializer.ts
+++ b/src/helpers/serializer.ts
@@ -1,17 +1,36 @@
 import { kebabCase } from 'lodash-es'
 
+import { DEFAULT_SUGGESTION_TRIGGER_CHAR } from '../constants/suggestions'
+
 import type { ParseRule, Schema } from '@tiptap/pm/model'
 
 /**
- * Builds a partial regular expression that includes valid URL schemas used by all the available
- * suggestion nodes from the given editor schema.
+ * Information derived from the suggestion nodes available in the editor schema, used by the
+ * HTML serializer to identify and transform suggestion links into spans.
+ */
+type SuggestionSchemaInfo = {
+    /**
+     * A partial regular expression that matches the URL schemes used by all the available
+     * suggestion nodes (e.g. `(?:mention|channel)://`).
+     */
+    urlSchemeRegex: string
+
+    /**
+     * A map from each URL scheme (e.g. `mention`, `channel`) to its configured trigger character
+     * (e.g. `@`, `#`).
+     */
+    triggerCharByScheme: Map<string, string>
+}
+
+/**
+ * Builds the information derived from all the suggestion nodes available in the given editor
+ * schema, in a single iteration. Returns `null` if there are no suggestion nodes in the schema.
  *
  * @param schema The editor schema to be used for suggestion nodes detection.
  *
- * @returns A partial regular expression with valid URL schemas for the available suggestion nodes,
- * `null` if there are no suggestion nodes in the editor schema.
+ * @returns A `SuggestionSchemaInfo` object, or `null` if there are no suggestion nodes.
  */
-function buildSuggestionSchemaPartialRegex(schema: Schema) {
+function buildSuggestionSchemaInfo(schema: Schema): SuggestionSchemaInfo | null {
     const suggestionNodes = Object.values(schema.nodes).filter((node) =>
         node.name.endsWith('Suggestion'),
     )
@@ -20,9 +39,22 @@ function buildSuggestionSchemaPartialRegex(schema: Schema) {
         return null
     }
 
-    return `(?:${suggestionNodes
-        .map((suggestionNode) => kebabCase(suggestionNode.name.replace(/Suggestion$/, '')))
-        .join('|')})://`
+    const triggerCharByScheme = new Map(
+        suggestionNodes.map((node) => [
+            kebabCase(node.name.replace(/Suggestion$/, '')),
+            String(
+                (node.spec as { triggerChar?: string }).triggerChar ??
+                    DEFAULT_SUGGESTION_TRIGGER_CHAR,
+            ),
+        ]),
+    )
+
+    const urlSchemes = [...triggerCharByScheme.keys()]
+
+    return {
+        urlSchemeRegex: `(?:${urlSchemes.join('|')})://`,
+        triggerCharByScheme,
+    }
 }
 
 /**
@@ -44,4 +76,4 @@ function extractTagsFromParseRules(
         .map((rule) => rule.tag as keyof HTMLElementTagNameMap)
 }
 
-export { buildSuggestionSchemaPartialRegex, extractTagsFromParseRules }
+export { buildSuggestionSchemaInfo, extractTagsFromParseRules }

--- a/src/serializers/html/html.test.ts
+++ b/src/serializers/html/html.test.ts
@@ -837,7 +837,7 @@ See the section on [\`code\`](#code).</p>`)
                     htmlSerializer.serialize(`Question: Who's the head of the Frontend team?
 Answer: [Henning M](mention://user:190200@doist.dev)`),
                 ).toBe(
-                    '<p>Question: Who\'s the head of the Frontend team?<br>Answer: <span data-mention="" data-id="user:190200@doist.dev" data-label="Henning M"></span></p>',
+                    '<p>Question: Who\'s the head of the Frontend team?<br>Answer: <span data-mention="" data-id="user:190200@doist.dev" data-label="Henning M">@Henning M</span></p>',
                 )
             })
 
@@ -846,7 +846,7 @@ Answer: [Henning M](mention://user:190200@doist.dev)`),
                     htmlSerializer.serialize(`Question: Who's the head of the Frontend team?
 Answer: [Henning M](mention://963827)`),
                 ).toBe(
-                    '<p>Question: Who\'s the head of the Frontend team?<br>Answer: <span data-mention="" data-id="963827" data-label="Henning M"></span></p>',
+                    '<p>Question: Who\'s the head of the Frontend team?<br>Answer: <span data-mention="" data-id="963827" data-label="Henning M">@Henning M</span></p>',
                 )
             })
 
@@ -855,7 +855,7 @@ Answer: [Henning M](mention://963827)`),
                     htmlSerializer.serialize(`Question: What's the best channel on Twist?
 Answer: [Doist Frontend](channel://190200)`),
                 ).toBe(
-                    '<p>Question: What\'s the best channel on Twist?<br>Answer: <span data-channel="" data-id="190200" data-label="Doist Frontend"></span></p>',
+                    '<p>Question: What\'s the best channel on Twist?<br>Answer: <span data-channel="" data-id="190200" data-label="Doist Frontend">@Doist Frontend</span></p>',
                 )
             })
 
@@ -865,7 +865,7 @@ Answer: [Doist Frontend](channel://190200)`),
                         'Hey [Alice](mention://123) and [Bob](mention://456), check [General](channel://789)',
                     ),
                 ).toBe(
-                    '<p>Hey <span data-mention="" data-id="123" data-label="Alice"></span> and <span data-mention="" data-id="456" data-label="Bob"></span>, check <span data-channel="" data-id="789" data-label="General"></span></p>',
+                    '<p>Hey <span data-mention="" data-id="123" data-label="Alice">@Alice</span> and <span data-mention="" data-id="456" data-label="Bob">@Bob</span>, check <span data-channel="" data-id="789" data-label="General">@General</span></p>',
                 )
             })
         })

--- a/src/serializers/html/plugins/rehype-suggestions.ts
+++ b/src/serializers/html/plugins/rehype-suggestions.ts
@@ -1,6 +1,6 @@
 import { visit } from 'unist-util-visit'
 
-import { buildSuggestionSchemaPartialRegex } from '../../../helpers/serializer'
+import { buildSuggestionSchemaInfo } from '../../../helpers/serializer'
 import { isHastElementNode, isHastTextNode } from '../../../helpers/unified'
 
 import type { Schema } from '@tiptap/pm/model'
@@ -13,15 +13,15 @@ import type { Transformer } from 'unified'
  * @param schema The editor schema to be used for suggestion nodes detection.
  */
 function rehypeSuggestions(schema: Schema): Transformer {
-    const suggestionSchemaPartialRegex = buildSuggestionSchemaPartialRegex(schema)
+    const suggestionSchemaInfo = buildSuggestionSchemaInfo(schema)
 
     // Return the tree as-is if the editor does not support suggestions
-    if (!suggestionSchemaPartialRegex) {
+    if (!suggestionSchemaInfo) {
         return (tree: HastNode) => tree
     }
 
     return (...[tree]: Parameters<Transformer>): ReturnType<Transformer> => {
-        const suggestionSchemaRegex = new RegExp(`^${suggestionSchemaPartialRegex}`)
+        const suggestionSchemaRegex = new RegExp(`^${suggestionSchemaInfo.urlSchemeRegex}`)
 
         visit(tree, 'element', (node: HastNode) => {
             if (
@@ -31,15 +31,25 @@ function rehypeSuggestions(schema: Schema): Transformer {
                 const [, urlScheme, id] =
                     /^([a-z-]+):\/\/(\S+)$/i.exec(String(node.properties?.href)) || []
 
-                // Replace the link element with a span containing the suggestion attributes
+                // Replace the link element with a span containing the suggestion attributes,
+                // keeping the visible label (prefixed with the trigger character) as text content
+                // so the span renders correctly when used outside of an editor.
                 if (urlScheme && id && isHastTextNode(node.children[0])) {
+                    const label = node.children[0].value
+
+                    // The URL scheme was matched against the regex built from the same map of
+                    // suggestion nodes, so the trigger character is guaranteed to exist
+                    const triggerChar = suggestionSchemaInfo.triggerCharByScheme.get(
+                        urlScheme,
+                    ) as string
+
                     node.tagName = 'span'
                     node.properties = {
                         [`data-${urlScheme}`]: '',
                         'data-id': id,
-                        'data-label': node.children[0].value,
+                        'data-label': label,
                     }
-                    node.children = []
+                    node.children[0].value = `${triggerChar}${label}`
                 }
             }
         })


### PR DESCRIPTION
## Overview

Makes the HTML serializer output directly renderable for suggestion nodes (mentions, channels, etc.) by including the trigger character and label as text content inside the span, instead of leaving it empty.

Before, the serializer output empty spans like `<span data-mention data-id="123" data-label="Alice"></span>`. This only "worked" because Tiptap parses the data attributes and re-renders the visible content via the suggestion extension's `renderHTML`. If you drop this HTML into any other rendering context (a browser, a React component using `dangerouslySetInnerHTML`, etc.), the mention shows as nothing because the span is empty.

After this PR, the output is `<span data-mention data-id="123" data-label="Alice">@Alice</span>` - self-contained and directly renderable. Tiptap still understands it (it reads from `data-label`), and any other consumer can render it as-is.

The trigger character is configurable per suggestion extension (`@`, `#`, etc.), so `createSuggestionExtension` now exposes it on the node spec via `extendNodeSchema`. The `rehype-suggestions` plugin reads it from the schema and prepends it to the label text. Default trigger char (`@`) lives in a new shared constant under `src/constants/suggestions.ts`.

This is forward-looking: it unblocks future use cases where the HTML serializer's output is rendered without going through the editor (for example, replacing `MarkdownContent` in todoist-web with a Markdown-to-React renderer built on these serializers). It also gives consumers a direct way to read the trigger character from a specific extension instance via `schema.nodes.{type}Suggestion.spec.triggerChar`, without having to track it separately or hardcode it.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
- [x] Added/updated unit test cases

## Test plan

- Smoke test the `Rich-text → Default` story in Storybook
    - [x] Type `@` and select a mention from the dropdown - it still renders and serializes the same
    - [x] Type `#` and select a channel suggestion - same
- CI checks should be green