### PR TITLE
fix(serializers): follow-up fixes to suggestion HTML output

### DIFF
--- a/src/helpers/schema.ts
+++ b/src/helpers/schema.ts
@@ -24,23 +24,13 @@ function isPlainTextDocument(schema: Schema): boolean {
 
 /**
  * Computes a string ID that identifies a given editor schema which can be used for object mapping.
- * The trigger character of each suggestion node is included in the ID so schemas that differ only
- * in suggestion configuration produce distinct cache keys.
  *
  * @param schema The current editor document schema.
  *
  * @returns A string ID matching the editor schema.
  */
 function computeSchemaId(schema: Schema) {
-    const suggestionTriggers = Object.values(schema.nodes)
-        .filter((node) => node.name.endsWith('Suggestion'))
-        .map((node) => `${node.name}=${(node.spec as { triggerChar?: string }).triggerChar ?? ''}`)
-
-    return [
-        ...Object.keys(schema.marks),
-        ...Object.keys(schema.nodes),
-        ...suggestionTriggers,
-    ].join()
+    return [...Object.keys(schema.marks), ...Object.keys(schema.nodes)].join()
 }
 
 export { computeSchemaId, isMultilineDocument, isPlainTextDocument }

--- a/src/helpers/schema.ts
+++ b/src/helpers/schema.ts
@@ -24,13 +24,23 @@ function isPlainTextDocument(schema: Schema): boolean {
 
 /**
  * Computes a string ID that identifies a given editor schema which can be used for object mapping.
+ * The trigger character of each suggestion node is included in the ID so schemas that differ only
+ * in suggestion configuration produce distinct cache keys.
  *
  * @param schema The current editor document schema.
  *
  * @returns A string ID matching the editor schema.
  */
 function computeSchemaId(schema: Schema) {
-    return [...Object.keys(schema.marks), ...Object.keys(schema.nodes)].join()
+    const suggestionTriggers = Object.values(schema.nodes)
+        .filter((node) => node.name.endsWith('Suggestion'))
+        .map((node) => `${node.name}=${(node.spec as { triggerChar?: string }).triggerChar ?? ''}`)
+
+    return [
+        ...Object.keys(schema.marks),
+        ...Object.keys(schema.nodes),
+        ...suggestionTriggers,
+    ].join()
 }
 
 export { computeSchemaId, isMultilineDocument, isPlainTextDocument }

--- a/src/helpers/serializer.ts
+++ b/src/helpers/serializer.ts
@@ -2,7 +2,19 @@ import { kebabCase } from 'lodash-es'
 
 import { DEFAULT_SUGGESTION_TRIGGER_CHAR } from '../constants/suggestions'
 
-import type { ParseRule, Schema } from '@tiptap/pm/model'
+import type { NodeType, ParseRule, Schema } from '@tiptap/pm/model'
+
+/**
+ * Extracts the URL scheme used by a suggestion node (e.g. `mention`, `channel`) from its node
+ * name (e.g. `mentionSuggestion`, `channelSuggestion`).
+ *
+ * @param node The suggestion node type.
+ *
+ * @returns The URL scheme as a kebab-case string.
+ */
+function getSuggestionUrlScheme(node: NodeType): string {
+    return kebabCase(node.name.replace(/Suggestion$/, ''))
+}
 
 /**
  * Information derived from the suggestion nodes available in the editor schema, used by the
@@ -41,7 +53,7 @@ function buildSuggestionSchemaInfo(schema: Schema): SuggestionSchemaInfo | null 
 
     const triggerCharByScheme = new Map(
         suggestionNodes.map((node) => [
-            kebabCase(node.name.replace(/Suggestion$/, '')),
+            getSuggestionUrlScheme(node),
             String(
                 (node.spec as { triggerChar?: string }).triggerChar ??
                     DEFAULT_SUGGESTION_TRIGGER_CHAR,
@@ -76,4 +88,4 @@ function extractTagsFromParseRules(
         .map((rule) => rule.tag as keyof HTMLElementTagNameMap)
 }
 
-export { buildSuggestionSchemaInfo, extractTagsFromParseRules }
+export { buildSuggestionSchemaInfo, extractTagsFromParseRules, getSuggestionUrlScheme }

--- a/src/helpers/serializer.ts
+++ b/src/helpers/serializer.ts
@@ -70,6 +70,27 @@ function buildSuggestionSchemaInfo(schema: Schema): SuggestionSchemaInfo | null 
 }
 
 /**
+ * Computes a string ID that identifies the configured trigger characters of all the suggestion
+ * nodes in the given editor schema. Used to discriminate cache keys for serializers whose output
+ * depends on the trigger character (e.g. the HTML serializer).
+ *
+ * @param schema The current editor document schema.
+ *
+ * @returns A string ID matching the suggestion trigger characters in the schema.
+ */
+function computeSuggestionTriggerCharsId(schema: Schema): string {
+    const suggestionSchemaInfo = buildSuggestionSchemaInfo(schema)
+
+    if (!suggestionSchemaInfo) {
+        return ''
+    }
+
+    return [...suggestionSchemaInfo.triggerCharByScheme]
+        .map(([scheme, triggerChar]) => `${scheme}=${triggerChar}`)
+        .join()
+}
+
+/**
  * Extract all tags from the given parse rules argument, and returns an array of said tags.
  *
  * @param parseRules The parse rules for a DOM node or inline style.
@@ -88,4 +109,9 @@ function extractTagsFromParseRules(
         .map((rule) => rule.tag as keyof HTMLElementTagNameMap)
 }
 
-export { buildSuggestionSchemaInfo, extractTagsFromParseRules, getSuggestionUrlScheme }
+export {
+    buildSuggestionSchemaInfo,
+    computeSuggestionTriggerCharsId,
+    extractTagsFromParseRules,
+    getSuggestionUrlScheme,
+}

--- a/src/helpers/serializer.ts
+++ b/src/helpers/serializer.ts
@@ -35,6 +35,18 @@ type SuggestionSchemaInfo = {
 }
 
 /**
+ * Returns all suggestion nodes available in the given editor schema (e.g. `mentionSuggestion`,
+ * `channelSuggestion`).
+ *
+ * @param schema The editor schema to be used for suggestion nodes detection.
+ *
+ * @returns An array of `NodeType` objects for the available suggestion nodes.
+ */
+function getSuggestionNodes(schema: Schema): NodeType[] {
+    return Object.values(schema.nodes).filter((node) => node.name.endsWith('Suggestion'))
+}
+
+/**
  * Builds the information derived from all the suggestion nodes available in the given editor
  * schema, in a single iteration. Returns `null` if there are no suggestion nodes in the schema.
  *
@@ -43,9 +55,7 @@ type SuggestionSchemaInfo = {
  * @returns A `SuggestionSchemaInfo` object, or `null` if there are no suggestion nodes.
  */
 function buildSuggestionSchemaInfo(schema: Schema): SuggestionSchemaInfo | null {
-    const suggestionNodes = Object.values(schema.nodes).filter((node) =>
-        node.name.endsWith('Suggestion'),
-    )
+    const suggestionNodes = getSuggestionNodes(schema)
 
     if (suggestionNodes.length === 0) {
         return null
@@ -113,5 +123,6 @@ export {
     buildSuggestionSchemaInfo,
     computeSuggestionTriggerCharsId,
     extractTagsFromParseRules,
+    getSuggestionNodes,
     getSuggestionUrlScheme,
 }

--- a/src/serializers/html/html.test.ts
+++ b/src/serializers/html/html.test.ts
@@ -827,7 +827,7 @@ See the section on [\`code\`](#code).</p>`)
                     getSchema([
                         RichTextKit,
                         createSuggestionExtension('mention'),
-                        createSuggestionExtension('channel'),
+                        createSuggestionExtension('channel').configure({ triggerChar: '#' }),
                     ]),
                 )
             })
@@ -855,7 +855,7 @@ Answer: [Henning M](mention://963827)`),
                     htmlSerializer.serialize(`Question: What's the best channel on Twist?
 Answer: [Doist Frontend](channel://190200)`),
                 ).toBe(
-                    '<p>Question: What\'s the best channel on Twist?<br>Answer: <span data-channel="" data-id="190200" data-label="Doist Frontend">@Doist Frontend</span></p>',
+                    '<p>Question: What\'s the best channel on Twist?<br>Answer: <span data-channel="" data-id="190200" data-label="Doist Frontend">#Doist Frontend</span></p>',
                 )
             })
 
@@ -865,7 +865,7 @@ Answer: [Doist Frontend](channel://190200)`),
                         'Hey [Alice](mention://123) and [Bob](mention://456), check [General](channel://789)',
                     ),
                 ).toBe(
-                    '<p>Hey <span data-mention="" data-id="123" data-label="Alice">@Alice</span> and <span data-mention="" data-id="456" data-label="Bob">@Bob</span>, check <span data-channel="" data-id="789" data-label="General">@General</span></p>',
+                    '<p>Hey <span data-mention="" data-id="123" data-label="Alice">@Alice</span> and <span data-mention="" data-id="456" data-label="Bob">@Bob</span>, check <span data-channel="" data-id="789" data-label="General">#General</span></p>',
                 )
             })
         })

--- a/src/serializers/html/html.test.ts
+++ b/src/serializers/html/html.test.ts
@@ -252,6 +252,28 @@ describe('HTML Serializer', () => {
                 expect(htmlSerializerA).not.toBe(htmlSerializerB)
             })
         })
+
+        describe('when two editor schemas differ only by suggestion `triggerChar`', () => {
+            test('`getHTMLSerializerInstance` returns different instances and outputs', () => {
+                const htmlSerializerA = getHTMLSerializerInstance(
+                    getSchema([
+                        PlainTextKit,
+                        createSuggestionExtension('mention').configure({ triggerChar: '@' }),
+                    ]),
+                )
+                const htmlSerializerB = getHTMLSerializerInstance(
+                    getSchema([
+                        PlainTextKit,
+                        createSuggestionExtension('mention').configure({ triggerChar: '#' }),
+                    ]),
+                )
+
+                expect(htmlSerializerA).not.toBe(htmlSerializerB)
+                expect(htmlSerializerA.serialize('[Alice](mention://1)')).not.toBe(
+                    htmlSerializerB.serialize('[Alice](mention://1)'),
+                )
+            })
+        })
     })
 
     describe('Plain-text Document', () => {

--- a/src/serializers/html/html.test.ts
+++ b/src/serializers/html/html.test.ts
@@ -379,20 +379,23 @@ describe('HTML Serializer', () => {
                     htmlSerializer.serialize(`Question: Who's the head of the Frontend team?
 Answer: [Henning M](mention://963827)`),
                 ).toBe(
-                    '<p>Question: Who&#39;s the head of the Frontend team?</p><p>Answer: <span data-mention data-id="963827" data-label="Henning M"></span></p>',
+                    '<p>Question: Who&#39;s the head of the Frontend team?</p><p>Answer: <span data-mention data-id="963827" data-label="Henning M">@Henning M</span></p>',
                 )
             })
 
             test('channel suggestion HTML output is correct', () => {
                 const htmlSerializer = createHTMLSerializer(
-                    getSchema([PlainTextKit, createSuggestionExtension('channel')]),
+                    getSchema([
+                        PlainTextKit,
+                        createSuggestionExtension('channel').configure({ triggerChar: '#' }),
+                    ]),
                 )
 
                 expect(
                     htmlSerializer.serialize(`Question: What's the best channel on Twist?
 Answer: [Doist Frontend](channel://190200)`),
                 ).toBe(
-                    '<p>Question: What&#39;s the best channel on Twist?</p><p>Answer: <span data-channel data-id="190200" data-label="Doist Frontend"></span></p>',
+                    '<p>Question: What&#39;s the best channel on Twist?</p><p>Answer: <span data-channel data-id="190200" data-label="Doist Frontend">#Doist Frontend</span></p>',
                 )
             })
 
@@ -404,7 +407,7 @@ Answer: [Doist Frontend](channel://190200)`),
                 expect(
                     htmlSerializer.serialize('[Henning M](mention://user:190200@doist.dev)'),
                 ).toBe(
-                    '<p><span data-mention data-id="user:190200@doist.dev" data-label="Henning M"></span></p>',
+                    '<p><span data-mention data-id="user:190200@doist.dev" data-label="Henning M">@Henning M</span></p>',
                 )
             })
 
@@ -416,7 +419,7 @@ Answer: [Doist Frontend](channel://190200)`),
                 expect(
                     htmlSerializer.serialize('([Henning M](mention://user:190200@doist.dev))'),
                 ).toBe(
-                    '<p>(<span data-mention data-id="user:190200@doist.dev" data-label="Henning M"></span>)</p>',
+                    '<p>(<span data-mention data-id="user:190200@doist.dev" data-label="Henning M">@Henning M</span>)</p>',
                 )
             })
 
@@ -425,7 +428,7 @@ Answer: [Doist Frontend](channel://190200)`),
                     getSchema([
                         PlainTextKit,
                         createSuggestionExtension('mention'),
-                        createSuggestionExtension('channel'),
+                        createSuggestionExtension('channel').configure({ triggerChar: '#' }),
                     ]),
                 )
 
@@ -434,7 +437,7 @@ Answer: [Doist Frontend](channel://190200)`),
                         'Hey [Alice](mention://123) and [Bob](mention://456), check [General](channel://789)',
                     ),
                 ).toBe(
-                    '<p>Hey <span data-mention data-id="123" data-label="Alice"></span> and <span data-mention data-id="456" data-label="Bob"></span>, check <span data-channel data-id="789" data-label="General"></span></p>',
+                    '<p>Hey <span data-mention data-id="123" data-label="Alice">@Alice</span> and <span data-mention data-id="456" data-label="Bob">@Bob</span>, check <span data-channel data-id="789" data-label="General">#General</span></p>',
                 )
             })
         })

--- a/src/serializers/html/html.ts
+++ b/src/serializers/html/html.ts
@@ -69,7 +69,8 @@ function createHTMLSerializerForPlainTextEditor(schema: Schema) {
 
                     htmlResult = htmlResult.replace(
                         new RegExp(`\\[([^\\[]+)\\]\\((?:${linkSchema}):\\/\\/([^\\s)]+)\\)`, 'gm'),
-                        `<span data-${linkSchema} data-id="$2" data-label="$1">${triggerChar}$1</span>`,
+                        (_, label, id) =>
+                            `<span data-${linkSchema} data-id="${id}" data-label="${label}">${triggerChar}${label}</span>`,
                     )
                 })
 

--- a/src/serializers/html/html.ts
+++ b/src/serializers/html/html.ts
@@ -6,9 +6,8 @@ import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import { unified } from 'unified'
 
-import { DEFAULT_SUGGESTION_TRIGGER_CHAR } from '../../constants/suggestions'
 import { computeSchemaId, isPlainTextDocument } from '../../helpers/schema'
-import { getSuggestionUrlScheme } from '../../helpers/serializer'
+import { buildSuggestionSchemaInfo } from '../../helpers/serializer'
 
 import { rehypeCodeBlock } from './plugins/rehype-code-block'
 import { rehypeImage } from './plugins/rehype-image'
@@ -57,22 +56,17 @@ function createHTMLSerializerForPlainTextEditor(schema: Schema) {
             let htmlResult = escape(markdown)
 
             // Serialize all suggestion links if any suggestion node exists in the schema
-            Object.values(schema.nodes)
-                .filter((node) => node.name.endsWith('Suggestion'))
-                .forEach((suggestionNode) => {
-                    const linkSchema = getSuggestionUrlScheme(suggestionNode)
+            const suggestionSchemaInfo = buildSuggestionSchemaInfo(schema)
 
-                    const triggerChar = String(
-                        (suggestionNode.spec as { triggerChar?: string }).triggerChar ??
-                            DEFAULT_SUGGESTION_TRIGGER_CHAR,
-                    )
-
+            if (suggestionSchemaInfo) {
+                for (const [linkSchema, triggerChar] of suggestionSchemaInfo.triggerCharByScheme) {
                     htmlResult = htmlResult.replace(
                         new RegExp(`\\[([^\\[]+)\\]\\((?:${linkSchema}):\\/\\/([^\\s)]+)\\)`, 'gm'),
                         (_, label, id) =>
                             `<span data-${linkSchema} data-id="${id}" data-label="${label}">${triggerChar}${label}</span>`,
                     )
-                })
+                }
+            }
 
             // Return the serialized HTML with every line wrapped in a paragraph element
             return htmlResult.replace(/^([^\n]+)\n?|\n+/gm, `<p>$1</p>`)

--- a/src/serializers/html/html.ts
+++ b/src/serializers/html/html.ts
@@ -1,4 +1,4 @@
-import { escape, kebabCase } from 'lodash-es'
+import { escape } from 'lodash-es'
 import rehypeMinifyWhitespace from 'rehype-minify-whitespace'
 import rehypeStringify from 'rehype-stringify'
 import remarkBreaks from 'remark-breaks'
@@ -7,6 +7,7 @@ import remarkRehype from 'remark-rehype'
 import { unified } from 'unified'
 
 import { computeSchemaId, isPlainTextDocument } from '../../helpers/schema'
+import { getSuggestionUrlScheme } from '../../helpers/serializer'
 
 import { rehypeCodeBlock } from './plugins/rehype-code-block'
 import { rehypeImage } from './plugins/rehype-image'
@@ -58,7 +59,7 @@ function createHTMLSerializerForPlainTextEditor(schema: Schema) {
             Object.values(schema.nodes)
                 .filter((node) => node.name.endsWith('Suggestion'))
                 .forEach((suggestionNode) => {
-                    const linkSchema = kebabCase(suggestionNode.name.replace(/Suggestion$/, ''))
+                    const linkSchema = getSuggestionUrlScheme(suggestionNode)
 
                     htmlResult = htmlResult.replace(
                         new RegExp(`\\[([^\\[]+)\\]\\((?:${linkSchema}):\\/\\/([^\\s)]+)\\)`, 'gm'),

--- a/src/serializers/html/html.ts
+++ b/src/serializers/html/html.ts
@@ -6,6 +6,7 @@ import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import { unified } from 'unified'
 
+import { DEFAULT_SUGGESTION_TRIGGER_CHAR } from '../../constants/suggestions'
 import { computeSchemaId, isPlainTextDocument } from '../../helpers/schema'
 import { getSuggestionUrlScheme } from '../../helpers/serializer'
 
@@ -61,9 +62,14 @@ function createHTMLSerializerForPlainTextEditor(schema: Schema) {
                 .forEach((suggestionNode) => {
                     const linkSchema = getSuggestionUrlScheme(suggestionNode)
 
+                    const triggerChar = String(
+                        (suggestionNode.spec as { triggerChar?: string }).triggerChar ??
+                            DEFAULT_SUGGESTION_TRIGGER_CHAR,
+                    )
+
                     htmlResult = htmlResult.replace(
                         new RegExp(`\\[([^\\[]+)\\]\\((?:${linkSchema}):\\/\\/([^\\s)]+)\\)`, 'gm'),
-                        `<span data-${linkSchema} data-id="$2" data-label="$1"></span>`,
+                        `<span data-${linkSchema} data-id="$2" data-label="$1">${triggerChar}$1</span>`,
                     )
                 })
 

--- a/src/serializers/html/html.ts
+++ b/src/serializers/html/html.ts
@@ -7,7 +7,10 @@ import remarkRehype from 'remark-rehype'
 import { unified } from 'unified'
 
 import { computeSchemaId, isPlainTextDocument } from '../../helpers/schema'
-import { buildSuggestionSchemaInfo } from '../../helpers/serializer'
+import {
+    buildSuggestionSchemaInfo,
+    computeSuggestionTriggerCharsId,
+} from '../../helpers/serializer'
 
 import { rehypeCodeBlock } from './plugins/rehype-code-block'
 import { rehypeImage } from './plugins/rehype-image'
@@ -179,7 +182,10 @@ const htmlSerializerInstanceById: HTMLSerializerInstanceById = {}
  * @returns The HTML serializer instance for the given editor schema.
  */
 function getHTMLSerializerInstance(schema: Schema) {
-    const id = computeSchemaId(schema)
+    const schemaId = computeSchemaId(schema)
+    const triggerCharsId = computeSuggestionTriggerCharsId(schema)
+
+    const id = [schemaId, triggerCharsId].join('|')
 
     if (!htmlSerializerInstanceById[id]) {
         htmlSerializerInstanceById[id] = createHTMLSerializer(schema)

--- a/src/serializers/html/plugins/rehype-suggestions.ts
+++ b/src/serializers/html/plugins/rehype-suggestions.ts
@@ -20,9 +20,9 @@ function rehypeSuggestions(schema: Schema): Transformer {
         return (tree: HastNode) => tree
     }
 
-    return (...[tree]: Parameters<Transformer>): ReturnType<Transformer> => {
-        const suggestionSchemaRegex = new RegExp(`^${suggestionSchemaInfo.urlSchemeRegex}`)
+    const suggestionSchemaRegex = new RegExp(`^${suggestionSchemaInfo.urlSchemeRegex}`)
 
+    return (...[tree]: Parameters<Transformer>): ReturnType<Transformer> => {
         visit(tree, 'element', (node: HastNode) => {
             if (
                 isHastElementNode(node, 'a') &&

--- a/src/serializers/markdown/markdown.ts
+++ b/src/serializers/markdown/markdown.ts
@@ -2,6 +2,7 @@ import Turndown from 'turndown'
 
 import { REGEX_PUNCTUATION } from '../../constants/regular-expressions'
 import { computeSchemaId, isPlainTextDocument } from '../../helpers/schema'
+import { getSuggestionNodes } from '../../helpers/serializer'
 
 import { image } from './plugins/image'
 import { listItem } from './plugins/list-item'
@@ -155,11 +156,9 @@ function createMarkdownSerializer(schema: Schema): MarkdownSerializerReturnType 
     }
 
     // Add a custom rule for all suggestion nodes available in the schema
-    Object.values(schema.nodes)
-        .filter((node) => node.name.endsWith('Suggestion'))
-        .forEach((suggestionNode) => {
-            turndown.use(suggestion(suggestionNode))
-        })
+    getSuggestionNodes(schema).forEach((suggestionNode) => {
+        turndown.use(suggestion(suggestionNode))
+    })
 
     // Return a normalized `serialize` function
     return {

--- a/src/serializers/markdown/plugins/suggestion.ts
+++ b/src/serializers/markdown/plugins/suggestion.ts
@@ -1,4 +1,4 @@
-import { kebabCase } from 'lodash-es'
+import { getSuggestionUrlScheme } from '../../../helpers/serializer'
 
 import type { NodeType } from '@tiptap/pm/model'
 import type Turndown from 'turndown'
@@ -10,7 +10,7 @@ import type Turndown from 'turndown'
  * @param nodeType The node object that matches this rule.
  */
 function suggestion(nodeType: NodeType): Turndown.Plugin {
-    const attributeType = kebabCase(nodeType.name.replace(/Suggestion$/, ''))
+    const attributeType = getSuggestionUrlScheme(nodeType)
 
     return (turndown: Turndown) => {
         turndown.addRule(nodeType.name, {


### PR DESCRIPTION
## Overview

Follow-up fixes to [#1341](https://github.com/Doist/typist/pull/1341), addressing review feedback that wasn't pushed before that PR was merged. The fixes cover both real defects and small refactors:

- **Plain-text suggestion path was still emitting empty spans.** The original PR only updated the rich-text rehype plugin; the plain-text regex-replacement branch in `html.ts` was overlooked. The label is now included (prefixed with the configured trigger character) as text content in both modes.
- **Schema cache key didn't account for `triggerChar`.** `computeSchemaId` only included mark and node names, so two schemas with the same suggestion nodes but different `triggerChar` configs produced the same cache key and shared one serializer. This was a latent bug before, but #1341 made the output depend on `triggerChar`, so cache pollution would now render the wrong prefix.
- **Custom trigger character wasn't exercised in tests.** The rich-text and plain-text suggestion tests both used the default `@` for every node, so the trigger-char wiring wasn't covered end-to-end. The channel suggestion test now configures `triggerChar: '#'` and asserts `#Doist Frontend`.
- **Suggestion regex was recompiled on every AST transformation** in `rehype-suggestions`. Moved out of the returned closure so it compiles once per plugin invocation.
- **Suggestion URL scheme extraction was duplicated** (`kebabCase(node.name.replace(/Suggestion$/, ''))`) across three files. Extracted into a `getSuggestionUrlScheme` helper in `src/helpers/serializer.ts`.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
- [x] Added/updated unit test cases

## Test plan

- Smoke test the `Rich-text → Default` story in Storybook
    - [ ] Type `@` and select a mention from the dropdown - it still renders and serializes the same
    - [ ] Type `#` and select a channel suggestion - same
- CI checks should be green