### PR TITLE
ci: block PRs to next when next is behind main

### DIFF
--- a/.github/workflows/check-next-branch-sync.yml
+++ b/.github/workflows/check-next-branch-sync.yml
@@ -1,0 +1,48 @@
+name: Next Branch Sync
+
+on:
+    pull_request:
+        branches:
+            - next
+        types:
+            - opened
+            - reopened
+            - synchronize
+
+permissions:
+    contents: read
+
+jobs:
+    verify-next-contains-main:
+        name: Verify `next` contains `main`
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - name: Fetch `main` and `next`
+              run: |
+                  git fetch origin main:refs/remotes/origin/main
+                  git fetch origin next:refs/remotes/origin/next
+
+            - name: Verify `main` is merged into `next`
+              run: |
+                  if ! git merge-base --is-ancestor origin/main origin/next; then
+                      echo "::error::'next' is behind 'main'. Sync 'next' with 'main' before merging this PR."
+                      {
+                          echo "### ❌ \`next\` is behind \`main\`"
+                          echo ""
+                          echo "Sync \`next\` with \`main\` before merging this PR:"
+                          echo ""
+                          echo '```sh'
+                          echo "git checkout next"
+                          echo "git merge main -m 'chore: sync next with main [skip ci]'"
+                          echo "git push origin next"
+                          echo '```'
+                      } >> "$GITHUB_STEP_SUMMARY"
+                      exit 1
+                  fi

--- a/.github/workflows/check-next-branch-sync.yml
+++ b/.github/workflows/check-next-branch-sync.yml
@@ -24,11 +24,6 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Fetch `main` and `next`
-              run: |
-                  git fetch origin main:refs/remotes/origin/main
-                  git fetch origin next:refs/remotes/origin/next
-
             - name: Verify `main` is merged into `next`
               run: |
                   if ! git merge-base --is-ancestor origin/main origin/next; then


### PR DESCRIPTION
## Overview

Adds a required CI check that fails when a PR targets `next` while `next` is behind `main`. This enforces the pre-release branch sync rule already documented in `CONTRIBUTING.md` so it can't be missed or forgotten.

The check uses `git merge-base --is-ancestor` to verify that every commit on `main` is reachable from `next`. On failure, it emits a GitHub error annotation and writes a Markdown summary with the exact sync commands.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

Code review should be sufficient. After merge, the check needs to be added to the required status checks in branch protection for `next` for the block to actually take effect; until then it runs but doesn't gate merging.