### PR TITLE
feat(deps): move shared application utilities back to peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,7 @@
             },
             "peerDependencies": {
                 "emoji-regex": "^10.2.1",
-                "linkifyjs": "^4.1.1",
+                "linkifyjs": "^4.3.2",
                 "lodash-es": "^4.17.21",
                 "react": "^18.0.0",
                 "react-dom": "^18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,6 @@
                 "@tiptap/pm": "2.27.2",
                 "@tiptap/react": "2.27.2",
                 "@tiptap/suggestion": "2.27.2",
-                "emoji-regex": "10.6.0",
-                "linkifyjs": "4.3.3",
-                "lodash-es": "4.17.23",
                 "mdast-util-gfm-autolink-literal": "2.0.1",
                 "mdast-util-gfm-strikethrough": "2.0.0",
                 "micromark-extension-gfm-autolink-literal": "2.1.0",
@@ -113,6 +110,9 @@
                 "npm": "^10.9.2 || >= 11.5.1"
             },
             "peerDependencies": {
+                "emoji-regex": "^10.2.1",
+                "linkifyjs": "^4.1.1",
+                "lodash-es": "^4.17.21",
                 "react": "^18.0.0",
                 "react-dom": "^18.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     },
     "peerDependencies": {
         "emoji-regex": "^10.2.1",
-        "linkifyjs": "^4.1.1",
+        "linkifyjs": "^4.3.2",
         "lodash-es": "^4.17.21",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -87,9 +87,6 @@
         "@tiptap/pm": "2.27.2",
         "@tiptap/react": "2.27.2",
         "@tiptap/suggestion": "2.27.2",
-        "emoji-regex": "10.6.0",
-        "linkifyjs": "4.3.3",
-        "lodash-es": "4.17.23",
         "mdast-util-gfm-autolink-literal": "2.0.1",
         "mdast-util-gfm-strikethrough": "2.0.0",
         "micromark-extension-gfm-autolink-literal": "2.1.0",
@@ -156,6 +153,9 @@
         "vitest": "4.1.7"
     },
     "peerDependencies": {
+        "emoji-regex": "^10.2.1",
+        "linkifyjs": "^4.1.1",
+        "lodash-es": "^4.17.21",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
     }


### PR DESCRIPTION
## Overview

Follow-up to #1351.

That PR moved every non-React peer dep into `dependencies`, which was correct for the pure-internal markdown chain (`unified`, `remark`/`rehype`/`mdast`/`micromark`/`unist` plugins) since consumers never import those directly, but wrong for `linkifyjs`, `emoji-regex`, and `lodash-es`. Those three are application-level utilities consumers commonly use in their own code, so leaving them as regular deps causes silent bundle duplication when consumer pins diverge from Typist's pins. Confirmed in practice on [Doist/todoist-web#17906](https://github.com/Doist/todoist-web/pull/17906): two copies of `linkifyjs` ended up in the task editor chunk.

Moves those three back to `peerDependencies` with broad ranges so npm enforces alignment at install time and bundlers ship a single copy. The pure internals stay where they are.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

Code review and CI are sufficient.
