### PR TITLE
fix: replace wrapping empty textblock when inserting block-only Markdown content

### DIFF
--- a/src/extensions/core/extra-editor-commands/commands/insert-markdown-content-at.ts
+++ b/src/extensions/core/extra-editor-commands/commands/insert-markdown-content-at.ts
@@ -74,9 +74,10 @@ function insertMarkdownContentAt(
                 options.parseOptions,
             )
 
-            let isOnlyBlockContent = true
+            // Check if the parsed content is non-empty and composed of block nodes only (the
+            // initial value guards against an empty insert deleting the wrapping textblock below)
+            let isOnlyBlockContent = content.content.childCount > 0
 
-            // Check if the parsed content is composed of block nodes only
             content.content.forEach((node) => {
                 isOnlyBlockContent = isOnlyBlockContent ? node.isBlock : false
             })

--- a/src/extensions/core/extra-editor-commands/commands/insert-markdown-content-at.ts
+++ b/src/extensions/core/extra-editor-commands/commands/insert-markdown-content-at.ts
@@ -62,7 +62,7 @@ function insertMarkdownContentAt(
             }
 
             // Get the start and end positions from the provided position
-            const { from, to } =
+            let { from, to } =
                 typeof position === 'number'
                     ? { from: position, to: position }
                     : { from: position.from, to: position.to }
@@ -73,6 +73,29 @@ function insertMarkdownContentAt(
                 parseHtmlToElement(htmlContent),
                 options.parseOptions,
             )
+
+            let isOnlyBlockContent = true
+
+            // Check if the parsed content is composed of block nodes only
+            content.content.forEach((node) => {
+                isOnlyBlockContent = isOnlyBlockContent ? node.isBlock : false
+            })
+
+            // Expand the insertion range to replace the wrapping empty textblock when only block
+            // content is inserted at a cursor position, mirroring the official `insertContentAt`
+            // command behaviour (e.g., a table pasted into an empty paragraph should replace the
+            // paragraph, instead of keeping the empty paragraph below the table)
+            if (from === to && isOnlyBlockContent) {
+                const { parent } = tr.doc.resolve(from)
+
+                const isEmptyTextBlock =
+                    parent.isTextblock && !parent.type.spec.code && !parent.childCount
+
+                if (isEmptyTextBlock) {
+                    from -= 1
+                    to += 1
+                }
+            }
 
             // Inserts the content into the editor while preserving the current selection
             tr.replaceRange(from, to, content)


### PR DESCRIPTION
## Overview

The `insertMarkdownContentAt` command (which also powers `insertMarkdownContent` and the `PasteMarkdown` extension) inserts parsed content with `tr.replaceRange`, without the empty-textblock handling that the official `insertContentAt` command implements. When block-only content is inserted at a cursor position inside an empty paragraph, ProseMirror's fitting algorithm cannot always merge the content into the paragraph, and the empty paragraph lingers next to the inserted content.

This PR mirrors the official [`insertContentAt` behaviour](https://github.com/ueberdosis/tiptap/blob/v2.27.1/packages/core/src/commands/insertContentAt.ts#L130-L143): when only block content is inserted at a cursor position within an empty (non-code) textblock, the insertion range is expanded to replace the wrapping textblock itself.

Note that all built-in nodes already replace the empty paragraph correctly: their parsed slices are either closed (images, horizontal rules) or open through layers that ProseMirror's fitting algorithm can close and join cleanly against a paragraph boundary (code blocks, blockquotes, lists, which bottom out in textblocks). As such, this change has no observable effect with the current built-in schema. The bug becomes observable with nodes whose slices are open through multiple non-textblock structural layers — concretely, the upcoming table support (`table > tableRow > tableHeader > paragraph`, where pasting a Markdown table left an empty paragraph next to the table), and potentially custom extensions passed to `<TypistEditor>` with similar nesting.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

Regression-tested the existing behaviour (which should remain unchanged) on the preview Storybook:

- Open the `Rich-text → Default` story
- Paste Markdown content of each kind into the **empty** editor (plain text, `- list`, `> quote`, ` ```code``` `, `![image](https://octodex.github.com/images/octobiwan.jpg)`, `---`)
    - [ ] Observe that the content is inserted without a lingering empty paragraph, and the Markdown output matches the pasted input
- Type some text, then paste block Markdown content after it
    - [ ] Observe that the content is inserted below the text, with no empty paragraph in between