### PR TITLE
fix: do not register list extensions when the paragraph extension is disabled

### DIFF
--- a/src/extensions/rich-text/rich-text-kit.ts
+++ b/src/extensions/rich-text/rich-text-kit.ts
@@ -67,7 +67,8 @@ type RichTextKitOptions = {
     bold: Partial<BoldOptions> | false
 
     /**
-     * Set options for the `BulletList` extension, or `false` to disable.
+     * Set options for the `BulletList` extension, or `false` to disable. This extension is always
+     * disabled when the `paragraph` option is disabled.
      */
     bulletList: Partial<RichTextBulletListOptions> | false
 
@@ -132,17 +133,20 @@ type RichTextKitOptions = {
     link: Partial<RichTextLinkOptions> | false
 
     /**
-     * Set options for the `ListItem` extension, or `false` to disable.
+     * Set options for the `ListItem` extension, or `false` to disable. This extension is always
+     * disabled when the `paragraph` option is disabled.
      */
     listItem: Partial<ListItemOptions> | false
 
     /**
-     * Set options for the `ListKeymap` extension, or `false` to disable.
+     * Set options for the `ListKeymap` extension, or `false` to disable. This extension is always
+     * disabled when the `paragraph` option is disabled.
      */
     listKeymap: Partial<ListKeymapOptions> | false
 
     /**
-     * Set options for the `OrderedList` extension, or `false` to disable.
+     * Set options for the `OrderedList` extension, or `false` to disable. This extension is always
+     * disabled when the `paragraph` option is disabled.
      */
     orderedList: Partial<RichTextOrderedListOptions> | false
 
@@ -209,7 +213,10 @@ const RichTextKit = Extension.create<RichTextKitOptions>({
             extensions.push(Bold.configure(this.options?.bold))
         }
 
-        if (this.options.bulletList !== false) {
+        // List items are restricted to paragraph-first content (i.e. `'paragraph block*'`), so a
+        // schema with list nodes but no `paragraph` node would throw during schema creation, which
+        // is why all list extensions are skipped when the `Paragraph` extension is disabled
+        if (this.options.bulletList !== false && this.options.paragraph !== false) {
             extensions.push(RichTextBulletList.configure(this.options?.bulletList))
         }
 
@@ -301,15 +308,15 @@ const RichTextKit = Extension.create<RichTextKitOptions>({
             extensions.push(RichTextLink.configure(this.options?.link))
         }
 
-        if (this.options.listItem !== false) {
+        if (this.options.listItem !== false && this.options.paragraph !== false) {
             extensions.push(ListItem.configure(this.options?.listItem))
         }
 
-        if (this.options.listKeymap !== false) {
+        if (this.options.listKeymap !== false && this.options.paragraph !== false) {
             extensions.push(ListKeymap.configure(this.options?.listKeymap))
         }
 
-        if (this.options.orderedList !== false) {
+        if (this.options.orderedList !== false && this.options.paragraph !== false) {
             extensions.push(RichTextOrderedList.configure(this.options?.orderedList))
         }
 

--- a/src/helpers/schema.test.ts
+++ b/src/helpers/schema.test.ts
@@ -64,5 +64,11 @@ describe('Helper: Schema', () => {
                 'link,bold,italic,boldAndItalics,strike,code,paragraph,blockquote,bulletList,codeBlock,doc,hardBreak,heading,horizontalRule,image,listItem,orderedList,text',
             )
         })
+
+        test('returns a string ID without the list extensions when the `Paragraph` extension is disabled', () => {
+            expect(computeSchemaId(getSchema([RichTextKit.configure({ paragraph: false })]))).toBe(
+                'link,bold,italic,boldAndItalics,strike,code,blockquote,codeBlock,doc,hardBreak,heading,horizontalRule,image,text',
+            )
+        })
     })
 })


### PR DESCRIPTION
## Overview

Configuring `RichTextKit` with `paragraph: false` crashes during schema creation:

```
SyntaxError: No node type or group 'paragraph' found (in content expression 'paragraph block*')
```

The root cause is that the kit still registers the list extensions when the `Paragraph` extension is disabled, and `ListItem` declares `content: 'paragraph block*'`, which references the now-missing `paragraph` node type. The bulleted/ordered list nodes would also dangle without `listItem`, and `ListKeymap` is pointless without list nodes.

This PR fixes the crash by silently skipping the registration of all list-related extensions (`BulletList`, `ListItem`, `ListKeymap`, and `OrderedList`) when the `paragraph` option is disabled, and documents this behavior in the `RichTextKitOptions` doc comments. The default schema (i.e. with paragraphs enabled) is unchanged.

This bug is pre-existing (it has been around since the kit was introduced, but nobody disables paragraphs), and it's unrelated to other in-flight PRs.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
- [x] Added/updated unit test cases and/or end-to-end test cases
- [ ] Added/updated documentation to Storybook or `README.md`

## Test plan

- `getSchema([RichTextKit.configure({ paragraph: false })])` used to throw the `SyntaxError` above; it now builds a valid schema without the `bulletList`, `orderedList`, and `listItem` nodes (covered by a new unit test in `src/helpers/schema.test.ts`)
- `getSchema([RichTextKit])` still produces the exact same schema as before (covered by the existing `#computeSchemaId` unit test)
- Full test suite passes: 156 tests across 8 files
