### PR TITLE
feat: export the `remarkTable` plugin from the package entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export { isMultilineDocument, isPlainTextDocument } from './helpers/schema'
 export { createHTMLSerializer, getHTMLSerializerInstance } from './serializers/html/html'
 export { remarkAutolinkLiteral } from './serializers/html/plugins/remark-autolink-literal'
 export { remarkStrikethrough } from './serializers/html/plugins/remark-strikethrough'
+export { remarkTable } from './serializers/html/plugins/remark-table'
 export {
     createMarkdownSerializer,
     getMarkdownSerializerInstance,


### PR DESCRIPTION
## Overview

When GFM table support landed in #1373, the new `remarkTable` plugin wasn't exported from the package entry point, unlike the existing `remarkAutolinkLiteral` and `remarkStrikethrough` plugins. This exports it so consumers can use it with their own unified/remark pipelines.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

Code review and CI checks should be sufficient.