### PR TITLE
refactor: only show the formatting toolbar in rich-text stories

### DIFF
--- a/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-decorator.tsx
+++ b/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-decorator.tsx
@@ -20,13 +20,13 @@ type TypistEditorPropsWithRef = Partial<
 type TypistEditorDecoratorProps = {
     Story: StoryFunction<Renderer, TypistEditorPropsWithRef>
     args: TypistEditorProps
-    withToolbar?: boolean
+    withRichTextFeatures?: boolean
     bottomFunctions?: React.ReactNode
 }
 
 const TypistEditorDecorator = forwardRef<TypistEditorRef, TypistEditorDecoratorProps>(
     function TypistEditorDecorator(
-        { Story, args, withToolbar = false, bottomFunctions },
+        { Story, args, withRichTextFeatures = false, bottomFunctions },
         forwardedRef,
     ) {
         const [typistEditor, setTypistEditor] = useState<CoreEditor | null>(null)
@@ -34,7 +34,7 @@ const TypistEditorDecorator = forwardRef<TypistEditorRef, TypistEditorDecoratorP
 
         const storyClassName = classNames('markdown-body', args.className)
 
-        const shouldRenderToolbar = typistEditor && withToolbar
+        const shouldRenderToolbar = typistEditor && withRichTextFeatures
 
         const handleUpdate = useCallback((props: UpdateProps) => {
             setMarkdownOutput(props.getMarkdown())

--- a/stories/typist-editor/plain-text-functions.stories.tsx
+++ b/stories/typist-editor/plain-text-functions.stories.tsx
@@ -61,7 +61,6 @@ export const Commands = meta.story({
                 <TypistEditorDecorator
                     Story={Story}
                     args={context.args}
-                    withToolbar={true}
                     bottomFunctions={
                         <>
                             <Button variant="secondary" onClick={handleCreateParagraphEndClick}>
@@ -112,7 +111,6 @@ export const Helpers = meta.story({
                 <TypistEditorDecorator
                     Story={Story}
                     args={context.args}
-                    withToolbar={true}
                     bottomFunctions={
                         <>
                             <Button variant="secondary" onClick={handleGetEditorClick}>

--- a/stories/typist-editor/rich-text-functions.stories.tsx
+++ b/stories/typist-editor/rich-text-functions.stories.tsx
@@ -61,7 +61,7 @@ export const Commands = meta.story({
                 <TypistEditorDecorator
                     Story={Story}
                     args={context.args}
-                    withToolbar={true}
+                    withRichTextFeatures={true}
                     bottomFunctions={
                         <>
                             <Button variant="secondary" onClick={handleCreateParagraphEndClick}>
@@ -112,7 +112,7 @@ export const Helpers = meta.story({
                 <TypistEditorDecorator
                     Story={Story}
                     args={context.args}
-                    withToolbar={true}
+                    withRichTextFeatures={true}
                     bottomFunctions={
                         <>
                             <Button variant="secondary" onClick={handleGetEditorClick}>

--- a/stories/typist-editor/rich-text.stories.tsx
+++ b/stories/typist-editor/rich-text.stories.tsx
@@ -170,7 +170,7 @@ export const Default = meta.story({
                 <TypistEditorDecorator
                     Story={Story}
                     args={storyArgs}
-                    withToolbar={true}
+                    withRichTextFeatures={true}
                     ref={typistEditorRef}
                 />
             )
@@ -218,7 +218,9 @@ export const Singleline = meta.story({
                 [context.args, handleKeyDown],
             )
 
-            return <TypistEditorDecorator Story={Story} args={storyArgs} withToolbar={true} />
+            return (
+                <TypistEditorDecorator Story={Story} args={storyArgs} withRichTextFeatures={true} />
+            )
         },
     ],
 })


### PR DESCRIPTION
## Overview

The story decorator rendered the formatting toolbar in the plain-text stories too, but a plain-text editor has no formatting commands (bold, headings, etc.), so the toolbar just sat there doing nothing.

This scopes it to the rich-text stories: the decorator's `withToolbar` flag becomes `withRichTextFeatures`, which only the rich-text stories opt into, and it's dropped from the plain-text stories.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Open the preview Storybook
- Open a `Plain-text → Functions` story and confirm there is no formatting toolbar above the editor
- Open the `Rich-text` stories and confirm the toolbar is unchanged
