### PR TITLE
fix(serializers): preserve inline Markdown characters in suggestion labels

### DIFF
--- a/src/helpers/serializer.ts
+++ b/src/helpers/serializer.ts
@@ -17,6 +17,22 @@ function getSuggestionUrlScheme(node: NodeType): string {
 }
 
 /**
+ * Backslash-escapes the inline Markdown characters in a suggestion label so that a serialized
+ * suggestion link (e.g. `[label](mention://id)`) parses back to the exact same label. Without it,
+ * characters such as backticks or asterisks in the label would be re-interpreted as Markdown and
+ * truncate the label when the content is parsed again. The escaped characters are backtick code
+ * spans, emphasis, strikethrough, autolinks, and the link brackets themselves. The backslash is
+ * matched first so it is never misread as an escape sequence for the character that follows it.
+ *
+ * @param label The raw suggestion label.
+ *
+ * @returns The label with all inline Markdown characters backslash-escaped.
+ */
+function escapeSuggestionLabel(label: string): string {
+    return label.replace(/[\\`*_~[\]<]/g, '\\$&')
+}
+
+/**
  * Information derived from the suggestion nodes available in the editor schema, used by the
  * HTML serializer to identify and transform suggestion links into spans.
  */
@@ -122,6 +138,7 @@ function extractTagsFromParseRules(
 export {
     buildSuggestionSchemaInfo,
     computeSuggestionTriggerCharsId,
+    escapeSuggestionLabel,
     extractTagsFromParseRules,
     getSuggestionNodes,
     getSuggestionUrlScheme,

--- a/src/helpers/unified.ts
+++ b/src/helpers/unified.ts
@@ -26,4 +26,24 @@ function isHastTextNode(node: HastNode): node is Text {
     return is(node, { type: 'text' })
 }
 
-export { isHastElementNode, isHastTextNode }
+/**
+ * Collects the plain text content of a hast node by concatenating the values of all its descendant
+ * text nodes, in document order.
+ *
+ * @param node The hast node to extract text content from.
+ *
+ * @returns The concatenated text content of the node and all its descendants.
+ */
+function getHastTextContent(node: HastNode): string {
+    if (isHastTextNode(node)) {
+        return node.value
+    }
+
+    if ('children' in node) {
+        return (node.children as HastNode[]).map(getHastTextContent).join('')
+    }
+
+    return ''
+}
+
+export { getHastTextContent, isHastElementNode, isHastTextNode }

--- a/src/serializers/html/html.test.ts
+++ b/src/serializers/html/html.test.ts
@@ -992,6 +992,38 @@ Answer: [Doist Frontend](channel://190200)`),
                     '<p>Hey <span data-mention="" data-id="123" data-label="Alice">@Alice</span> and <span data-mention="" data-id="456" data-label="Bob">@Bob</span>, check <span data-channel="" data-id="789" data-label="General">#General</span></p>',
                 )
             })
+
+            test('suggestion label with inline Markdown characters is not truncated', () => {
+                expect(htmlSerializer.serialize('[Use *bold* please](channel://1)')).toBe(
+                    '<p><span data-channel="" data-id="1" data-label="Use bold please">#Use bold please</span></p>',
+                )
+
+                expect(htmlSerializer.serialize('[Use _italic_ please](channel://1)')).toBe(
+                    '<p><span data-channel="" data-id="1" data-label="Use italic please">#Use italic please</span></p>',
+                )
+            })
+
+            test('suggestion label starting with inline Markdown is still converted', () => {
+                expect(htmlSerializer.serialize('[`code` first](channel://1)')).toBe(
+                    '<p><span data-channel="" data-id="1" data-label="code first">#code first</span></p>',
+                )
+
+                expect(htmlSerializer.serialize('[~~struck~~ start](channel://1)')).toBe(
+                    '<p><span data-channel="" data-id="1" data-label="struck start">#struck start</span></p>',
+                )
+            })
+
+            test('suggestion label with an autolink keeps the full text', () => {
+                expect(htmlSerializer.serialize('[mail <a@b.com> here](channel://1)')).toBe(
+                    '<p><span data-channel="" data-id="1" data-label="mail a@b.com here">#mail a@b.com here</span></p>',
+                )
+            })
+
+            test('escaped inline Markdown characters in a suggestion label are preserved', () => {
+                expect(htmlSerializer.serialize('[The future of \\`code\\`](channel://1)')).toBe(
+                    '<p><span data-channel="" data-id="1" data-label="The future of &#x60;code&#x60;">#The future of `code`</span></p>',
+                )
+            })
         })
     })
 })

--- a/src/serializers/html/plugins/rehype-suggestions.ts
+++ b/src/serializers/html/plugins/rehype-suggestions.ts
@@ -1,7 +1,7 @@
 import { visit } from 'unist-util-visit'
 
 import { buildSuggestionSchemaInfo } from '../../../helpers/serializer'
-import { isHastElementNode, isHastTextNode } from '../../../helpers/unified'
+import { getHastTextContent, isHastElementNode } from '../../../helpers/unified'
 
 import type { Schema } from '@tiptap/pm/model'
 import type { Node as HastNode } from 'hast'
@@ -31,12 +31,16 @@ function rehypeSuggestions(schema: Schema): Transformer {
                 const [, urlScheme, id] =
                     /^([a-z-]+):\/\/(\S+)$/i.exec(String(node.properties?.href)) || []
 
+                // The label is always meant to be plain text, so we flatten the full text content
+                // of the link instead of reading a single child. This keeps the label intact when
+                // the Markdown parser splits it into multiple inline nodes (e.g. a backtick code
+                // span or emphasis within the label).
+                const label = getHastTextContent(node)
+
                 // Replace the link element with a span containing the suggestion attributes,
                 // keeping the visible label (prefixed with the trigger character) as text content
                 // so the span renders correctly when used outside of an editor.
-                if (urlScheme && id && isHastTextNode(node.children[0])) {
-                    const label = node.children[0].value
-
+                if (urlScheme && id && label) {
                     // The URL scheme was matched against the regex built from the same map of
                     // suggestion nodes, so the trigger character is guaranteed to exist
                     const triggerChar = suggestionSchemaInfo.triggerCharByScheme.get(
@@ -49,7 +53,7 @@ function rehypeSuggestions(schema: Schema): Transformer {
                         'data-id': id,
                         'data-label': label,
                     }
-                    node.children[0].value = `${triggerChar}${label}`
+                    node.children = [{ type: 'text', value: `${triggerChar}${label}` }]
                 }
             }
         })

--- a/src/serializers/markdown/markdown.test.ts
+++ b/src/serializers/markdown/markdown.test.ts
@@ -416,6 +416,18 @@ Answer: [Doist Frontend](channel://190200)`)
                     'Hey [Alice](mention://123) and [Bob](mention://456), check [General](channel://789)',
                 )
             })
+
+            test('inline Markdown characters in a suggestion label are not escaped', () => {
+                const markdownSerializer = createMarkdownSerializer(
+                    getSchema([PlainTextKit, createSuggestionExtension('channel')]),
+                )
+
+                expect(
+                    markdownSerializer.serialize(
+                        '<p><span data-channel data-id="1" data-label="The future of `code`">#The future of `code`</span></p>',
+                    ),
+                ).toBe('[The future of `code`](channel://1)')
+            })
         })
     })
 
@@ -1100,6 +1112,30 @@ Answer: [Doist Frontend](channel://190200)`)
                 ).toBe(
                     'Hey [Alice](mention://123) and [Bob](mention://456), check [General](channel://789)',
                 )
+            })
+
+            test('inline Markdown characters in a suggestion label are escaped', () => {
+                const markdownSerializer = createMarkdownSerializer(
+                    getSchema([RichTextKit, createSuggestionExtension('channel')]),
+                )
+
+                expect(
+                    markdownSerializer.serialize(
+                        '<p><span data-channel data-id="1" data-label="Use *bold* and _more_">#Use *bold* and _more_</span></p>',
+                    ),
+                ).toBe('[Use \\*bold\\* and \\_more\\_](channel://1)')
+
+                expect(
+                    markdownSerializer.serialize(
+                        '<p><span data-channel data-id="1" data-label="~~struck~~ label">#~~struck~~ label</span></p>',
+                    ),
+                ).toBe('[\\~\\~struck\\~\\~ label](channel://1)')
+
+                expect(
+                    markdownSerializer.serialize(
+                        '<p><span data-channel data-id="1" data-label="a[b]c &lt;x&gt;">#a[b]c &lt;x&gt;</span></p>',
+                    ),
+                ).toBe('[a\\[b\\]c \\<x>](channel://1)')
             })
         })
     })

--- a/src/serializers/markdown/markdown.ts
+++ b/src/serializers/markdown/markdown.ts
@@ -181,7 +181,7 @@ function createMarkdownSerializer(schema: Schema): MarkdownSerializerReturnType 
 
     // Add a custom rule for all suggestion nodes available in the schema
     getSuggestionNodes(schema).forEach((suggestionNode) => {
-        turndown.use(suggestion(suggestionNode))
+        turndown.use(suggestion(suggestionNode, isPlainTextDocument(schema)))
     })
 
     // Return a normalized `serialize` function

--- a/src/serializers/markdown/plugins/suggestion.ts
+++ b/src/serializers/markdown/plugins/suggestion.ts
@@ -1,4 +1,4 @@
-import { getSuggestionUrlScheme } from '../../../helpers/serializer'
+import { escapeSuggestionLabel, getSuggestionUrlScheme } from '../../../helpers/serializer'
 
 import type { NodeType } from '@tiptap/pm/model'
 import type Turndown from 'turndown'
@@ -8,8 +8,9 @@ import type Turndown from 'turndown'
  * extension factory function.
  *
  * @param nodeType The node object that matches this rule.
+ * @param isPlainText Specifies if the schema represents a plain-text document.
  */
-function suggestion(nodeType: NodeType): Turndown.Plugin {
+function suggestion(nodeType: NodeType, isPlainText: boolean): Turndown.Plugin {
     const attributeType = getSuggestionUrlScheme(nodeType)
 
     return (turndown: Turndown) => {
@@ -21,7 +22,13 @@ function suggestion(nodeType: NodeType): Turndown.Plugin {
                 const label = String((node as Element).getAttribute('data-label'))
                 const id = String((node as Element).getAttribute('data-id'))
 
-                return `[${label}](${attributeType}://${id})`
+                // Rich-text editors parse the label back as inline Markdown, so its Markdown
+                // characters are escaped to keep the label intact across a serialize then parse
+                // round-trip. Plain-text editors keep the label verbatim when parsing it back, so
+                // it must not be escaped.
+                const serializedLabel = isPlainText ? label : escapeSuggestionLabel(label)
+
+                return `[${serializedLabel}](${attributeType}://${id})`
             },
         })
     }


### PR DESCRIPTION
## Overview

Suggestion chips built from a Markdown link (like `[Title](hashtag://id)`) lost part of their label whenever the title contained inline-Markdown characters. A title such as ``The future of `code` `` produced a chip labelled `#The future of ` (everything from the backtick onward was dropped), and a title that *started* with such characters produced no chip at all and was left as a plain link. The same happened with emphasis (`*`, `_`), strikethrough (`~~`), and autolinks. The cause is that the label is parsed as inline Markdown, which splits it into several pieces, and only the first piece was being read.

This reads the full text of the link when building the chip, so the label stays intact no matter how the Markdown parser splits it, and a chip is now created even when its label starts with inline Markdown. It also escapes those characters when a chip is serialized back to Markdown, so a label keeps its exact text when content is parsed again, for example while editing existing content. Escaping applies to rich-text editors only, since plain-text editors keep the label verbatim when parsing it back.

## Reference

- Comms thread: https://comms.todoist.com/69/ch/CaVwVqsJ5M73bmSTT4geh/t/Cc8abjjHYirbpCMDSjTkW/

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
- [x] Added/updated unit test cases and/or end-to-end test cases

## Test plan

> [!TIP]
> Open the preview Storybook deployed to Netlify and select the `Typist Editor / Rich-text → Default` story.

- Place the cursor in the editor and paste the block below as plain text with `Cmd/Ctrl+Shift+V`

````
[The future of `code`](hashtag://1)

[Use *bold* please](hashtag://1)

[Status ~~done~~ now](hashtag://1)

[Ping <a@b.com> today](hashtag://1)

[`code` first](hashtag://1)
````

- [ ] Observe that the editor shows five chips with their full labels, matching:

```
#The future of code

#Use bold please

#Status done now

#Ping a@b.com today

#code first
```

## Demo

**Before / After**

https://github.com/user-attachments/assets/e2300016-4f8a-4d7a-bae3-8789ee82e11b

