### PR TITLE
test(serializers): cover backtick and backslash escaping in suggestion labels

### DIFF
--- a/src/serializers/markdown/markdown.test.ts
+++ b/src/serializers/markdown/markdown.test.ts
@@ -1127,6 +1127,12 @@ Answer: [Doist Frontend](channel://190200)`)
 
                 expect(
                     markdownSerializer.serialize(
+                        '<p><span data-channel data-id="1" data-label="The future of `code`">#The future of `code`</span></p>',
+                    ),
+                ).toBe('[The future of \\`code\\`](channel://1)')
+
+                expect(
+                    markdownSerializer.serialize(
                         '<p><span data-channel data-id="1" data-label="~~struck~~ label">#~~struck~~ label</span></p>',
                     ),
                 ).toBe('[\\~\\~struck\\~\\~ label](channel://1)')
@@ -1136,6 +1142,12 @@ Answer: [Doist Frontend](channel://190200)`)
                         '<p><span data-channel data-id="1" data-label="a[b]c &lt;x&gt;">#a[b]c &lt;x&gt;</span></p>',
                     ),
                 ).toBe('[a\\[b\\]c \\<x>](channel://1)')
+
+                expect(
+                    markdownSerializer.serialize(
+                        '<p><span data-channel data-id="1" data-label="back\\slash">#back\\slash</span></p>',
+                    ),
+                ).toBe('[back\\\\slash](channel://1)')
             })
         })
     })


### PR DESCRIPTION
## Overview

The rich-text suggestion label escaping test covered six of the eight characters handled by `escapeSuggestionLabel`. This adds the two missing cases, backtick and backslash, so every escaped character is exercised in the serialization direction.

## Reference

- Follow-up to #1384

## Test plan

Code review and CI checks should be sufficient.
