### PR TITLE
fix(rich-text): Degrade pasted HTML tables to string when tables unavailable

### DIFF
--- a/src/extensions/rich-text/rich-text-kit.test.ts
+++ b/src/extensions/rich-text/rich-text-kit.test.ts
@@ -1,0 +1,56 @@
+import { RichTextKit } from './rich-text-kit'
+
+import type { RichTextKitOptions } from './rich-text-kit'
+
+/**
+ * Resolves the extensions that `RichTextKit` registers for a given set of options and returns their
+ * names. Invokes `addExtensions()` directly (rather than instantiating an `Editor`) so the registration
+ * logic can be asserted without building a ProseMirror view.
+ */
+function getRegisteredExtensionNames(options?: Partial<RichTextKitOptions>): string[] {
+    const kit = options ? RichTextKit.configure(options) : RichTextKit
+    const childExtensions =
+        kit.config.addExtensions?.call({
+            name: kit.name,
+            options: kit.options,
+            storage: kit.storage,
+            parent: undefined,
+        }) ?? []
+
+    return childExtensions.map((extension) => extension.name)
+}
+
+describe('Extension: RichTextKit', () => {
+    describe('PasteHTMLTableAsString registration', () => {
+        test('registers native tables (not the paste-as-string fallback) by default', () => {
+            const names = getRegisteredExtensionNames()
+
+            expect(names).toContain('table')
+            expect(names).not.toContain('pasteHTMLTableAsString')
+        })
+
+        test('registers the paste-as-string fallback when tables are disabled', () => {
+            const names = getRegisteredExtensionNames({ table: false })
+
+            expect(names).toContain('pasteHTMLTableAsString')
+            expect(names).not.toContain('table')
+        })
+
+        test('registers the paste-as-string fallback for singleline documents', () => {
+            const names = getRegisteredExtensionNames({ document: { multiline: false } })
+
+            expect(names).toContain('pasteHTMLTableAsString')
+            expect(names).not.toContain('table')
+        })
+
+        test('does not register the fallback when disabled via `pasteHTMLTableAsString: false`', () => {
+            const names = getRegisteredExtensionNames({
+                table: false,
+                pasteHTMLTableAsString: false,
+            })
+
+            expect(names).not.toContain('pasteHTMLTableAsString')
+            expect(names).not.toContain('table')
+        })
+    })
+})

--- a/src/extensions/rich-text/rich-text-kit.ts
+++ b/src/extensions/rich-text/rich-text-kit.ts
@@ -19,6 +19,7 @@ import { Typography } from '@tiptap/extension-typography'
 
 import { BLOCKQUOTE_EXTENSION_PRIORITY } from '../../constants/extension-priorities'
 import { CopyMarkdownSource } from '../shared/copy-markdown-source'
+import { PasteHTMLTableAsString } from '../shared/paste-html-table-as-string'
 import { PasteSinglelineText } from '../shared/paste-singleline-text'
 
 import { BoldAndItalics } from './bold-and-italics'
@@ -159,6 +160,16 @@ type RichTextKitOptions = {
      * Set to `false` to disable the `PasteEmojis` extension.
      */
     pasteEmojis: false
+
+    /**
+     * Set to `false` to disable the `PasteHTMLTableAsString` extension, which converts pasted HTML
+     * tables (e.g. from spreadsheets or GitHub Flavored Markdown) into space-separated paragraphs.
+     *
+     * This extension is only registered when native table support is unavailable (i.e. `table` is
+     * `false`, or the document is singleline). When tables are enabled, pasted tables become native
+     * tables instead, so this option has no effect.
+     */
+    pasteHTMLTableAsString: false
 
     /**
      * Set to `false` to disable the `PasteMarkdown` extension.
@@ -342,6 +353,12 @@ const RichTextKit = Extension.create<RichTextKitOptions>({
                 TableHeader.extend({ content: 'paragraph' }),
                 TableCell.extend({ content: 'paragraph' }),
             )
+        } else if (this.options.pasteHTMLTableAsString !== false) {
+            // When native tables aren't available (disabled, or a singleline document), gracefully
+            // degrade pasted HTML tables (from spreadsheets or GFM) into space-separated paragraphs
+            // instead of letting the cell contents run together. This mirrors the `PlainTextKit`,
+            // which always registers this extension since it never supports native tables
+            extensions.push(PasteHTMLTableAsString)
         }
 
         if (this.options.text !== false) {

--- a/src/extensions/shared/paste-html-table-as-string.test.ts
+++ b/src/extensions/shared/paste-html-table-as-string.test.ts
@@ -80,5 +80,29 @@ describe('Extension: PasteHTMLTableAsString', () => {
 
             expect(result).toBe('<p><span>A</span> <strong>B</strong></p>')
         })
+
+        describe('cheap table guard (skips DOMParser for non-table HTML)', () => {
+            test('returns non-table HTML verbatim instead of re-serializing it', () => {
+                // Unclosed/non-normalized markup that the DOMParser path would rewrite; the guard
+                // short-circuits before parsing, so it must come back byte-for-byte unchanged.
+                const html = '<p>Hello<br>world<p>unclosed'
+                expect(transformPastedHTML(html)).toBe(html)
+            })
+
+            test('does not treat the literal word "table" in text as a table', () => {
+                const html = '<p>Reserve a table for dinner</p>'
+                expect(transformPastedHTML(html)).toBe(html)
+            })
+
+            test('matches a table element with attributes', () => {
+                const html = '<table class="data"><tr><td>A</td><td>B</td></tr></table>'
+                expect(transformPastedHTML(html)).toBe('<p>A B</p>')
+            })
+
+            test('matches a table element regardless of tag casing', () => {
+                const html = '<TABLE><TR><TD>A</TD><TD>B</TD></TR></TABLE>'
+                expect(transformPastedHTML(html)).toBe('<p>A B</p>')
+            })
+        })
     })
 })

--- a/src/extensions/shared/paste-html-table-as-string.ts
+++ b/src/extensions/shared/paste-html-table-as-string.ts
@@ -8,6 +8,12 @@ import { parseHtmlToElement } from '../../helpers/dom'
  * Transforms pasted HTML by converting tables to paragraphs while preserving surrounding content.
  */
 function transformPastedHTML(html: string): string {
+    // Cheap guard so non-table HTML pastes skip the full `DOMParser` parse below, which matters now
+    // that this extension is also registered for singleline and `table: false` rich-text editors.
+    if (!/<table[\s>]/i.test(html)) {
+        return html
+    }
+
     const body = parseHtmlToElement(html)
     const tables = body.querySelectorAll('table')
 


### PR DESCRIPTION
## Overview

Follows up to https://github.com/Doist/typist/pull/1373.

Register the `PasteHTMLTableAsString` extension in `RichTextKit` when native table support is unavailable (tables disabled or singleline document), so pasted HTML tables from spreadsheets or GFM become space-separated paragraphs instead of running together.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
- [x] Added/updated unit test cases and/or end-to-end test cases
- [ ] Added/updated documentation to Storybook or `README.md`

## Test plan

- Visit https://deploy-preview-1386--doist-typist.netlify.app/
- Open Rich-text > Singleline
- Paste a row from a spreadsheet ([sample spreadsheet](https://docs.google.com/spreadsheets/d/1iU_DkSdrHf0wxeb2nHSStLXUrHsGhDTDzQnRLIk4d9E/edit?usp=sharing))
- [ ] Verify that the space between cells is preserved

## Demo

| Before                      | After                      |
| --------------------------- | -------------------------- |
| <img width="1508" height="830" alt="Screenshot 2026-06-18 at 17 20 32" src="https://github.com/user-attachments/assets/e6dceebe-8058-4cd9-8ba8-bea13c672896" /> https://typist.doist.dev/?path=/story/typist-editor-rich-text--singleline | <img width="1512" height="830" alt="Screenshot 2026-06-18 at 17 20 24" src="https://github.com/user-attachments/assets/b06f2a67-9037-44d8-b2db-79e0a7ab16be" /> https://deploy-preview-1386--doist-typist.netlify.app/?path=/story/typist-editor-rich-text--singleline |
