### PR TITLE
feat(suggestion)!: read items on demand from a getter

### DIFF
--- a/src/factories/create-suggestion-extension.ts
+++ b/src/factories/create-suggestion-extension.ts
@@ -93,7 +93,7 @@ type SuggestionOptions<TSuggestionItem> = {
      */
     onSearchChange?: (
         query: string,
-        storage: SuggestionStorage<TSuggestionItem>,
+        items: TSuggestionItem[],
     ) => TSuggestionItem[] | Promise<TSuggestionItem[]>
 
     /**
@@ -101,21 +101,6 @@ type SuggestionOptions<TSuggestionItem> = {
      */
     onItemSelect?: (item: TSuggestionItem) => void
 }
-
-/**
- * The storage holding the suggestion items original array, and a collection indexed by the item id.
- */
-type SuggestionStorage<TSuggestionItem> = Readonly<{
-    /**
-     * The original array of suggestion items.
-     */
-    items: TSuggestionItem[]
-
-    /**
-     * A collection of suggestion items indexed by the item id.
-     */
-    itemsById: { readonly [id: SuggestionNodeAttributes['id']]: TSuggestionItem | undefined }
-}>
 
 /**
  * The return type for a suggestion extension created by the factory function.
@@ -133,15 +118,15 @@ type SuggestionExtensionResult<TSuggestionItem> = Node<SuggestionOptions<TSugges
  * specify the source item type, and use the optional `attributesMapping` option to map the
  * source properties to the internal `data-id` and `data-label` attributes.
  *
- * This factory function also stores the suggestion items internally in the editor storage (as-is,
- * and indexed by an identifier), as a way to make sure that if a previously referenced suggestion
- * changes its label, the editor will always render the most up-to-date label for the suggestion by
- * reading it from the storage. An example use case for this is when a user mention is added to the
- * editor, and the user changed its name afterwards, the editor will always render the most
- * up-to-date user name for the mention.
+ * When an already-inserted suggestion is rendered, its label is resolved by id from the current
+ * items, so it always reflects the latest label, falling back to the saved `data-label` attribute
+ * when the id is no longer present in the items.
  *
  * @param type A unique identifier for the suggestion extension type.
- * @param items An array of suggestion items to be stored in the editor storage.
+ * @param items The suggestion items, provided either as a static array or as a getter returning the
+ * current items. The editor is created once and the extension is never rebuilt, so a static array
+ * stays fixed for the lifetime of the extension; provide a getter when the items can change over
+ * time, so they are read on demand instead of captured once.
  * @param attributesMapping An object to map the `data-id` and `data-label` attributes with the
  * source item type properties.
  *
@@ -153,7 +138,7 @@ function createSuggestionExtension<
     } = SuggestionNodeAttributes,
 >(
     type: string,
-    items: TSuggestionItem[] = [],
+    items: TSuggestionItem[] | (() => TSuggestionItem[]) = [],
 
     // This type makes sure that if a generic type variable is specified, the `attributesMapping`
     // is also defined (and vice versa) along with making sure that at least one attribute is
@@ -178,8 +163,18 @@ function createSuggestionExtension<
     const idAttribute = String(attributesMapping[0]?.id ?? 'id')
     const labelAttribute = String(attributesMapping[0]?.label ?? 'label')
 
+    // Normalize the items into a getter, so a static array and a getter source are handled the
+    // same way internally. The getter is the single source of truth for the current items.
+    const getItems = typeof items === 'function' ? items : () => items
+
+    // Resolve a single item by its id from the current items. Used to look up the selected item
+    // and to resolve an inserted suggestion's label on demand, without keeping a stored index.
+    function findItemById(id: string): TSuggestionItem | undefined {
+        return getItems().find((item) => String(item[idAttribute]) === id)
+    }
+
     // Create a personalized suggestion extension
-    return Node.create<SuggestionOptions<TSuggestionItem>, SuggestionStorage<TSuggestionItem>>({
+    return Node.create<SuggestionOptions<TSuggestionItem>>({
         name: nodeType,
         priority: SUGGESTION_EXTENSION_PRIORITY,
         inline: true,
@@ -194,14 +189,6 @@ function createSuggestionExtension<
                 allowSpaces: false,
                 allowedPrefixes: [' '],
                 startOfLine: false,
-            }
-        },
-        addStorage() {
-            return {
-                items,
-                itemsById: Object.fromEntries(
-                    items.map((item) => [String(item[idAttribute]), item]),
-                ),
             }
         },
         // Expose the trigger character in the node spec so it can be read from the schema by
@@ -225,14 +212,14 @@ function createSuggestionExtension<
                     default: null,
                     parseHTML: (element: Element) => {
                         const id = String(element.getAttribute('data-id'))
-                        const item = this.storage.itemsById[id]
+                        const item = findItemById(id)
 
-                        // Attempt to read the item label from the storage first (as a way to make
-                        // sure that a previously referenced suggestion always renders the most
-                        // up-to-date label for the suggestion), and fallback to the `data-label`
-                        // attribute if the item is not found in the storage
+                        // Resolve the label from the current items so a previously inserted
+                        // suggestion always renders the most up-to-date label, and fall back to
+                        // the `data-label` attribute when the item is no longer present
                         const labelValue =
                             item?.[labelAttribute] ?? element.getAttribute('data-label')
+
                         return typeof labelValue === 'string' ? labelValue : ''
                     },
                     renderHTML: (attributes) => ({
@@ -274,7 +261,6 @@ function createSuggestionExtension<
                     onItemSelect,
                     dropdownRenderFn,
                 },
-                storage,
             } = this
 
             return [
@@ -285,13 +271,10 @@ function createSuggestionExtension<
                     allowedPrefixes,
                     allowSpaces,
                     startOfLine,
-                    items({ query, editor }) {
-                        return (
-                            onSearchChange?.(
-                                query,
-                                editor.storage[nodeType] as SuggestionStorage<TSuggestionItem>,
-                            ) || []
-                        )
+                    items({ query }) {
+                        // Read the current items on each query so the results reflect the latest
+                        // source instead of values captured when the extension was created.
+                        return onSearchChange?.(query, getItems()) || []
                     },
                     allow({ editor, range, state }) {
                         return (
@@ -322,7 +305,7 @@ function createSuggestionExtension<
                             ])
                             .run()
 
-                        const item = storage.itemsById[props.id]
+                        const item = findItemById(String(props.id))
 
                         if (item) {
                             onItemSelect?.(item)
@@ -342,5 +325,4 @@ export type {
     SuggestionOptions,
     SuggestionRendererProps,
     SuggestionRendererRef,
-    SuggestionStorage,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,6 @@ export type {
     SuggestionOptions,
     SuggestionRendererProps,
     SuggestionRendererRef,
-    SuggestionStorage,
 } from './factories/create-suggestion-extension'
 export { createSuggestionExtension } from './factories/create-suggestion-extension'
 export { isMultilineDocument, isPlainTextDocument } from './helpers/schema'

--- a/stories/documentation/usage/extensions.md
+++ b/stories/documentation/usage/extensions.md
@@ -50,8 +50,8 @@ function TypistEditorContainer({ content }) {
                     onExit(props) {},
                 }
             },
-            onSearchChange(query, storage) {
-                return storage.items.filter((item) => {
+            onSearchChange(query, items) {
+                return items.filter((item) => {
                     return item.name.toLowerCase().includes(query.toLowerCase())
                 })
             },
@@ -64,7 +64,4 @@ function TypistEditorContainer({ content }) {
 }
 ```
 
-A few observations about the example above:
-
-- The example takes advantage of the built-in storage to store the suggestion items internally, and use them to render the suggestions based on always up-to-date data. However, the storage is not mandatory, you can use the extension without it.
-- You may have noticed that the `createSuggestionExtension` function is called within a functional component, which means it will be re-created with every render. You may need to optimize this with `useMemo` to avoid re-creating the extension on every render.
+In the example, `onSearchChange` receives the current `items` and filters them against the query. You can provide `items` as a static array or as a getter (`() => MentionUser[]`). Because the editor is created only once, a getter is what keeps the suggestions in sync with a source that changes over time: it's read on demand whenever the current items are needed, rather than captured at mount.

--- a/stories/typist-editor/extensions/hashtag-suggestion.ts
+++ b/stories/typist-editor/extensions/hashtag-suggestion.ts
@@ -26,12 +26,12 @@ const HashtagSuggestion: SuggestionExtensionResult<HashtagSuggestionItem> =
         renderAriaLabel({ label }) {
             return `Hashtag: #${label}`
         },
-        async onSearchChange(query, storage) {
-            const storageItems = await new Promise((resolve) =>
+        async onSearchChange(query, items) {
+            const delayedItems = await new Promise((resolve) =>
                 setTimeout(resolve, random(500, 1500)),
-            ).then(() => storage.items)
+            ).then(() => items)
 
-            return storageItems.filter((item) => {
+            return delayedItems.filter((item) => {
                 return item.name.toLowerCase().includes(query.toLowerCase())
             })
         },

--- a/stories/typist-editor/extensions/mention-suggestion.ts
+++ b/stories/typist-editor/extensions/mention-suggestion.ts
@@ -26,8 +26,8 @@ const MentionSuggestion: SuggestionExtensionResult<MentionSuggestionItem> =
         renderAriaLabel({ label }) {
             return `Name: ${label}`
         },
-        onSearchChange(query, storage) {
-            return storage.items.filter((item) => {
+        onSearchChange(query, items) {
+            return items.filter((item) => {
                 return item.name.toLowerCase().includes(query.toLowerCase())
             })
         },


### PR DESCRIPTION
## Overview

`createSuggestionExtension` previously captured its items when the extension was built and cached them in the editor storage. Since the editor is now created once and kept for the component's lifetime, an extension whose items come from a source that changes over time would be stuck with the items present when the editor first mounted.

This makes the factory's `items` parameter accept either a static array or a getter, and reads the current items on demand wherever the factory needs them: filtering the search, resolving the selected item, and rendering an already-inserted suggestion's label. A getter keeps suggestions in sync with a changing source without recreating the editor, mirroring how other runtime data is read reactively from inside an extension. The internal storage cache is removed, since the items are no longer held anywhere.

This is a breaking change: `onSearchChange` receives the current items array as its second argument instead of a `storage` object, and the `SuggestionStorage` type is no longer exported. Migrating is a direct swap from `storage.items` to `items`.

## Reference

- Builds on the editor lifecycle change in #1387

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
- [x] Added/updated documentation to Storybook or `README.md`

## Test plan

> [!TIP]
> Open the preview Storybook deployed to Netlify

- Open the `Rich-text → Default` story
- Type `@` followed by part of a name
    - [ ] Observe that matching suggestions appear and narrow as you keep typing
- Select a suggestion from the list
    - [ ] Observe that it is inserted with the correct name
- Type `#` followed by part of a hashtag
    - [ ] Observe that matching suggestions appear and can be selected
