### PR TITLE
fix(typist-editor): correct editable state synchronization

### DIFF
--- a/src/components/typist-editor.tsx
+++ b/src/components/typist-editor.tsx
@@ -1,4 +1,12 @@
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react'
+import {
+    forwardRef,
+    useCallback,
+    useEffect,
+    useImperativeHandle,
+    useLayoutEffect,
+    useMemo,
+    useState,
+} from 'react'
 
 import { getSchema } from '@tiptap/core'
 import { Placeholder } from '@tiptap/extension-placeholder'
@@ -390,7 +398,8 @@ const TypistEditor = forwardRef<TypistEditorRef, TypistEditorProps>(function Typ
         ...(onDestroy ? { onDestroy } : {}),
     })
 
-    useEffect(
+    // Apply editability before paint so a read-only editor can't process a queued edit first
+    useLayoutEffect(
         function syncEditableState() {
             editor.setEditable(editable)
         },

--- a/src/components/typist-editor.tsx
+++ b/src/components/typist-editor.tsx
@@ -398,10 +398,16 @@ const TypistEditor = forwardRef<TypistEditorRef, TypistEditorProps>(function Typ
         ...(onDestroy ? { onDestroy } : {}),
     })
 
-    // Apply editability before paint so a read-only editor can't process a queued edit first
+    // Sync editability in a layout effect so it applies before the browser paints, closing the gap
+    // where a read-only editor could still process a queued keystroke or paste
     useLayoutEffect(
         function syncEditableState() {
-            editor.setEditable(editable)
+            // On mount the editor already has the correct editability, so this guard skips setting
+            // it again. The redundant call would emit an update event before the editor finishes
+            // initializing (a tick later), breaking extensions that initialize with it.
+            if (editor.isEditable !== editable) {
+                editor.setEditable(editable)
+            }
         },
         [editor, editable],
     )

--- a/src/components/typist-editor.tsx
+++ b/src/components/typist-editor.tsx
@@ -13,11 +13,7 @@ import { Placeholder } from '@tiptap/extension-placeholder'
 import { EditorContent, useEditor } from '@tiptap/react'
 
 import { ExtraEditorCommands } from '../extensions/core/extra-editor-commands/extra-editor-commands'
-import {
-    ViewEventHandlers,
-    ViewEventHandlersOptions,
-    ViewEventHandlersStorage,
-} from '../extensions/core/view-event-handlers'
+import { ViewEventHandlers, ViewEventHandlersOptions } from '../extensions/core/view-event-handlers'
 import { isMultilineDocument, isPlainTextDocument } from '../helpers/schema'
 import { getHTMLSerializerInstance } from '../serializers/html/html'
 import { getMarkdownSerializerInstance } from '../serializers/markdown/markdown'
@@ -415,10 +411,7 @@ const TypistEditor = forwardRef<TypistEditorRef, TypistEditorProps>(function Typ
     // The editor is created once, so push the latest handlers into the extension as they change
     useEffect(
         function syncViewEventHandlers() {
-            ;(editor.storage.viewEventHandlers as ViewEventHandlersStorage).setHandlers({
-                onClick,
-                onKeyDown,
-            })
+            editor.commands.setViewEventHandlers({ onClick, onKeyDown })
         },
         [editor, onClick, onKeyDown],
     )

--- a/src/components/typist-editor.tsx
+++ b/src/components/typist-editor.tsx
@@ -5,7 +5,11 @@ import { Placeholder } from '@tiptap/extension-placeholder'
 import { EditorContent, useEditor } from '@tiptap/react'
 
 import { ExtraEditorCommands } from '../extensions/core/extra-editor-commands/extra-editor-commands'
-import { ViewEventHandlers, ViewEventHandlersOptions } from '../extensions/core/view-event-handlers'
+import {
+    ViewEventHandlers,
+    ViewEventHandlersOptions,
+    ViewEventHandlersStorage,
+} from '../extensions/core/view-event-handlers'
 import { isMultilineDocument, isPlainTextDocument } from '../helpers/schema'
 import { getHTMLSerializerInstance } from '../serializers/html/html'
 import { getMarkdownSerializerInstance } from '../serializers/markdown/markdown'
@@ -396,7 +400,10 @@ const TypistEditor = forwardRef<TypistEditorRef, TypistEditorProps>(function Typ
     // The editor is created once, so push the latest handlers into the extension as they change
     useEffect(
         function syncViewEventHandlers() {
-            editor.storage.viewEventHandlers.setHandlers({ onClick, onKeyDown })
+            ;(editor.storage.viewEventHandlers as ViewEventHandlersStorage).setHandlers({
+                onClick,
+                onKeyDown,
+            })
         },
         [editor, onClick, onKeyDown],
     )

--- a/src/extensions/core/view-event-handlers.ts
+++ b/src/extensions/core/view-event-handlers.ts
@@ -76,4 +76,4 @@ const ViewEventHandlers = Extension.create<ViewEventHandlersOptions, ViewEventHa
 
 export { ViewEventHandlers }
 
-export type { ViewEventHandlersOptions }
+export type { ViewEventHandlersOptions, ViewEventHandlersStorage }

--- a/src/extensions/core/view-event-handlers.ts
+++ b/src/extensions/core/view-event-handlers.ts
@@ -23,12 +23,22 @@ type ViewEventHandlersOptions = {
     onKeyDown?: (event: KeyboardEvent, view: EditorView) => boolean | void
 }
 
-type ViewEventHandlersStorage = ViewEventHandlersOptions & {
-    /**
-     * Updates the handlers the plugin invokes. The editor component calls this as its handler
-     * props change, since the editor and its plugins are created only once.
-     */
-    setHandlers: (handlers: ViewEventHandlersOptions) => void
+type ViewEventHandlersStorage = ViewEventHandlersOptions
+
+/**
+ * Augment the official `@tiptap/core` module with extra commands, relevant for this extension, so
+ * that the compiler knows about them.
+ */
+declare module '@tiptap/core' {
+    interface Commands<ReturnType> {
+        viewEventHandlers: {
+            /**
+             * Updates the handlers the plugin invokes. The editor component calls this as its
+             * handler props change, since the editor and its plugins are created only once.
+             */
+            setViewEventHandlers: (handlers: ViewEventHandlersOptions) => ReturnType
+        }
+    }
 }
 
 /**
@@ -49,9 +59,15 @@ const ViewEventHandlers = Extension.create<ViewEventHandlersOptions, ViewEventHa
         return {
             onClick: this.options.onClick,
             onKeyDown: this.options.onKeyDown,
-            setHandlers(handlers) {
-                this.onClick = handlers.onClick
-                this.onKeyDown = handlers.onKeyDown
+        }
+    },
+    addCommands() {
+        return {
+            setViewEventHandlers: (handlers) => () => {
+                this.storage.onClick = handlers.onClick
+                this.storage.onKeyDown = handlers.onKeyDown
+
+                return true
             },
         }
     },
@@ -76,4 +92,4 @@ const ViewEventHandlers = Extension.create<ViewEventHandlersOptions, ViewEventHa
 
 export { ViewEventHandlers }
 
-export type { ViewEventHandlersOptions, ViewEventHandlersStorage }
+export type { ViewEventHandlersOptions }


### PR DESCRIPTION
## Overview

`TypistEditor` keeps the editor's `editable` state in sync through a React effect. This corrects two problems with that synchronization and tightens the typing around the internal view event handlers.

The effect previously ran after the browser painted, so switching the editor to read-only left a brief window where it was still writable and could process a queued keystroke or paste. Running the sync in a layout effect applies the change before paint and closes that window.

On mount the effect also re-applied the `editable` value the editor was already created with. That redundant call emitted an editor update before initialization finished, which arrived ahead of the editor's create event and could break extensions that set themselves up on creation. A guard now skips the call when the editable state already matches, so nothing runs on mount.

The internal access to the view event handlers storage is now typed instead of reaching through an untyped storage bag, so the contract is checked at compile time.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

Code review and CI checks should be sufficient.
