### PR TITLE
chore(deps): pin conventional changelog preset to v9

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,11 @@
             "matchPackageNames": ["/gfm-strikethrough$/"]
         },
         {
+            "description": "Keep v9 until semantic-release supports v10.",
+            "matchPackageNames": ["conventional-changelog-conventionalcommits"],
+            "allowedVersions": "<10"
+        },
+        {
             "matchPackageNames": ["/eslint/"],
             "enabled": false
         }


### PR DESCRIPTION
## Overview

Keeps Renovate on `conventional-changelog-conventionalcommits` v9 until semantic-release supports v10.

v10 changed its template API, while semantic-release 25 still uses the previous writer API. Merging #1404 would publish releases with an empty changelog body. Upstream recommends pinning v9 until its ecosystem completes the migration: https://github.com/semantic-release/release-notes-generator/issues/992

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Run `npx --package renovate renovate-config-validator .github/renovate.json`
- Confirm future v9 updates remain eligible while v10+ updates are excluded