### PR TITLE
feat: support React 19

### DIFF
--- a/.github/workflows/check-ci-validation.yml
+++ b/.github/workflows/check-ci-validation.yml
@@ -122,6 +122,50 @@ jobs:
               run: |
                   npm run test
 
+    react-18-compatibility:
+        name: React 18 Compatibility
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+
+        needs:
+            - prepare-workflow
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Prepare Node.js environment
+              uses: actions/setup-node@v6
+              with:
+                  cache: npm
+                  node-version-file: .node-version
+
+            # The cache is only restored, and never saved, because this job replaces
+            # React with an older version that the other jobs must not inherit.
+            - name: Restore project 'node_modules' directory
+              id: node-modules-cache
+              uses: actions/cache/restore@v5
+              with:
+                  key: node-modules-cache-${{ hashFiles('**/package-lock.json', '**/.node-version') }}
+                  path: node_modules/
+
+            - name: Install project npm dependencies
+              if: ${{ steps.node-modules-cache.outputs.cache-hit != 'true' }}
+              run: |
+                  npm ci
+
+            - name: Downgrade React to the oldest supported version
+              run: |
+                  npm install --no-save react@18 react-dom@18 @types/react@18 @types/react-dom@18
+
+            - name: Perform type checking with TypeScript
+              run: |
+                  npm run check:types
+
+            - name: Test codebase correctness
+              run: |
+                  npm run test
+
     build-package:
         name: Build Package
         runs-on: ubuntu-latest

--- a/.github/workflows/check-ci-validation.yml
+++ b/.github/workflows/check-ci-validation.yml
@@ -154,9 +154,11 @@ jobs:
               run: |
                   npm ci
 
+            # React 18 is frozen at its final release, while its types still receive
+            # patches, so only the runtime packages are pinned to an exact version
             - name: Downgrade React to the oldest supported version
               run: |
-                  npm install --no-save react@18 react-dom@18 @types/react@18 @types/react-dom@18
+                  npm install --no-save react@18.3.1 react-dom@18.3.1 @types/react@18 @types/react-dom@18
 
             - name: Perform type checking with TypeScript
               run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,8 +77,8 @@
                 "@testing-library/user-event": "14.6.1",
                 "@types/hast": "3.0.5",
                 "@types/lodash-es": "4.17.12",
-                "@types/react": "18.3.31",
-                "@types/react-dom": "18.3.7",
+                "@types/react": "19.2.17",
+                "@types/react-dom": "19.2.3",
                 "@types/react-syntax-highlighter": "15.5.13",
                 "@types/turndown": "5.0.6",
                 "@types/unist": "3.0.3",
@@ -93,8 +93,8 @@
                 "oxfmt": "0.60.0",
                 "oxlint": "1.75.0",
                 "publint": "0.3.21",
-                "react": "18.3.1",
-                "react-dom": "18.3.1",
+                "react": "19.2.8",
+                "react-dom": "19.2.8",
                 "react-icons": "5.7.0",
                 "react-markdown": "10.1.0",
                 "react-syntax-highlighter": "16.1.1",
@@ -120,8 +120,8 @@
                 "emoji-regex": "^10.2.1",
                 "linkifyjs": "^4.3.2",
                 "lodash-es": "^4.17.21",
-                "react": "^18.0.0",
-                "react-dom": "^18.0.0"
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/@actions/core": {
@@ -1588,32 +1588,32 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
-            "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+            "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@floating-ui/utils": "^0.2.10"
+                "@floating-ui/utils": "^0.2.12"
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.7.5",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
-            "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+            "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@floating-ui/core": "^1.7.4",
-                "@floating-ui/utils": "^0.2.10"
+                "@floating-ui/core": "^1.8.0",
+                "@floating-ui/utils": "^0.2.12"
             }
         },
         "node_modules/@floating-ui/utils": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-            "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+            "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
             "dev": true,
             "license": "MIT",
             "peer": true
@@ -2649,9 +2649,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2669,9 +2666,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2689,9 +2683,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2709,9 +2700,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2729,9 +2717,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2749,9 +2734,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2769,9 +2751,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2789,9 +2768,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2996,9 +2972,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3016,9 +2989,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3036,9 +3006,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3056,9 +3023,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3076,9 +3040,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3096,9 +3057,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3116,9 +3074,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3136,9 +3091,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3706,9 +3658,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3726,9 +3675,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3746,9 +3692,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3766,9 +3709,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3786,9 +3726,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3806,9 +3743,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4708,14 +4642,13 @@
             "license": "MIT"
         },
         "node_modules/@storybook/icons": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.0.2.tgz",
-            "integrity": "sha512-KZBCpXsshAIjczYNXR/rlxEtCUX/eAbpFNwKi8bcOomrLA4t/SyPz5RF+lVPO2oZBUE4sAkt43mfJUevQDSEEw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.1.0.tgz",
+            "integrity": "sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/@storybook/react": {
@@ -5654,32 +5587,24 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/prop-types": {
-            "version": "15.7.15",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/react": {
-            "version": "18.3.31",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-            "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+            "version": "19.2.17",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+            "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/prop-types": "*",
                 "csstype": "^3.2.2"
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "18.3.7",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-            "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+            "version": "19.2.3",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+            "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
-                "@types/react": "^18.0.0"
+                "@types/react": "^19.2.0"
             }
         },
         "node_modules/@types/react-syntax-highlighter": {
@@ -6365,9 +6290,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6382,9 +6304,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6399,9 +6318,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6416,9 +6332,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6433,9 +6346,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6450,9 +6360,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6537,9 +6444,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6554,9 +6458,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6571,9 +6472,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6588,9 +6486,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6605,9 +6500,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6622,9 +6514,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -10646,6 +10535,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/js-yaml": {
@@ -11379,6 +11269,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
@@ -16467,13 +16358,10 @@
             }
         },
         "node_modules/react": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "version": "19.2.8",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+            "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
             "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            },
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -16548,16 +16436,15 @@
             }
         },
         "node_modules/react-dom": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "version": "19.2.8",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+            "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
             "license": "MIT",
             "dependencies": {
-                "loose-envify": "^1.1.0",
-                "scheduler": "^0.23.2"
+                "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^18.3.1"
+                "react": "^19.2.8"
             }
         },
         "node_modules/react-focus-lock": {
@@ -17424,13 +17311,10 @@
             }
         },
         "node_modules/scheduler": {
-            "version": "0.23.2",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-            "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            }
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+            "license": "MIT"
         },
         "node_modules/semantic-release": {
             "version": "25.0.8",

--- a/package.json
+++ b/package.json
@@ -124,8 +124,8 @@
         "@testing-library/user-event": "14.6.1",
         "@types/hast": "3.0.5",
         "@types/lodash-es": "4.17.12",
-        "@types/react": "18.3.31",
-        "@types/react-dom": "18.3.7",
+        "@types/react": "19.2.17",
+        "@types/react-dom": "19.2.3",
         "@types/react-syntax-highlighter": "15.5.13",
         "@types/turndown": "5.0.6",
         "@types/unist": "3.0.3",
@@ -140,8 +140,8 @@
         "oxfmt": "0.60.0",
         "oxlint": "1.75.0",
         "publint": "0.3.21",
-        "react": "18.3.1",
-        "react-dom": "18.3.1",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
         "react-icons": "5.7.0",
         "react-markdown": "10.1.0",
         "react-syntax-highlighter": "16.1.1",
@@ -163,7 +163,7 @@
         "emoji-regex": "^10.2.1",
         "linkifyjs": "^4.3.2",
         "lodash-es": "^4.17.21",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
     }
 }


### PR DESCRIPTION
## Overview

Widens the React peer range to `^18.0.0 || ^19.0.0` and moves the development environment to React 19.

Today `@doist/typist` peers on React 18 only, which blocks consumers from even trying React 19: npm fails to resolve. `@doist/reactist` already allows both (`>=18.0.0 <20.0.0`), so Typist is the remaining gate. Both `todoist-web` and `comms-web` are still on React 18.3.1, so nothing changes for them right now.

Typist barely touches React — a single `forwardRef` component and a handful of hooks, with Tiptap handling the editor integration, and `@tiptap/react` already supports 17, 18, and 19. The built output is byte-for-byte identical whether it is compiled against React 18 or 19 types.

Since development now happens on React 19, a `React 18 Compatibility` job installs React 18 over the top of a normal install and runs the same type checking and test suite against it. That keeps the oldest supported version covered without aliased packages, extra configs, or duplicated scripts. When React 18 support is eventually dropped, deleting that job is the only cleanup needed. The job restores the shared `node_modules` cache but never saves it, so the downgraded tree cannot leak into the other jobs.

Replaces [#1325](https://github.com/Doist/typist/pull/1325), which bumped the same dependencies but left React 18 untested, and would not have published the widened range from a `chore` commit.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Observe that CI is green, which covers static analysis, tests, and the build on React 19, plus type checking and tests on React 18
- Open the Netlify preview Storybook and confirm the editor stories behave as expected under React 19
