### PR TITLE
chore(deps): pin semantic-release changelog and git plugins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,16 @@
             "allowedVersions": "<10"
         },
         {
+            "description": "Keep v6 until Node.js 24.15.0 is the minimum supported version.",
+            "matchPackageNames": ["@semantic-release/changelog"],
+            "allowedVersions": "<7"
+        },
+        {
+            "description": "Keep v10 until Node.js 24.15.0 is the minimum supported version.",
+            "matchPackageNames": ["@semantic-release/git"],
+            "allowedVersions": "<11"
+        },
+        {
             "matchPackageNames": ["/eslint/"],
             "enabled": false
         }


### PR DESCRIPTION
## Overview

Keeps Renovate on `@semantic-release/changelog` v6 and `@semantic-release/git` v10 until Node.js 24.15.0 becomes the minimum supported version.

Both new majors require Node `^22.22.2 || >=24.15`, while this repository targets 24.13.0 to stay in sync with its consumers. With `engine-strict=true`, `npm ci` fails outright on those versions, which is why Renovate could not even regenerate the lockfile in #1438. The upgrade is an ESM-only refactor, so nothing is lost by staying on the current majors.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)

## Test plan

- Run `npx --package renovate renovate-config-validator .github/renovate.json`
- Confirm future v6 and v10 updates remain eligible while newer majors are excluded

## Reference

- #1438