### PR TITLE
fix(serializers): preserve angle-bracket URLs as text

### DIFF
--- a/src/serializers/html/html.test.ts
+++ b/src/serializers/html/html.test.ts
@@ -622,6 +622,12 @@ Answer: [Doist Frontend](channel://190200)`),
                 )
             })
 
+            test('angle-bracket URLs are preserved as text', () => {
+                expect(htmlSerializer.serialize('<https://duckduckgo.com>')).toBe(
+                    '<p>&lt;https://duckduckgo.com></p>',
+                )
+            })
+
             test('styled links HTML output is correct', () => {
                 expect(htmlSerializer.serialize(MARKDOWN_INPUT_STYLED_LINKS)).toBe(
                     '<p>I love supporting the <strong><a href="https://eff.org">EFF</a></strong>.<br>I love supporting the <strong><a href="https://eff.org">https://eff.org</a></strong>.<br>This is the <em><a href="https://www.markdownguide.org">Markdown Guide</a></em>.<br>This is the <em><a href="https://www.markdownguide.org">https://www.markdownguide.org</a></em>.<br>See the section on <a href="#code"><code>code</code></a>.</p>',
@@ -807,6 +813,12 @@ console.log("hello")
                     .toBe(`<p>My favorite search engine is [Duck Duck Go](https://duckduckgo.com).
 My favorite search engine is [Duck Duck Go](https://duckduckgo.com "The best search engine for privacy").
 My favorite search engine is https://duckduckgo.com.</p>`)
+            })
+
+            test('angle-bracket URLs are preserved as text without the link extension', () => {
+                expect(htmlSerializer.serialize('<https://duckduckgo.com>')).toBe(
+                    '<p>&lt;https://duckduckgo.com></p>',
+                )
             })
 
             test('styled links HTML output is preserved', () => {

--- a/src/serializers/html/html.ts
+++ b/src/serializers/html/html.ts
@@ -19,6 +19,7 @@ import { rehypeTable } from './plugins/rehype-table'
 import { rehypeTaskList } from './plugins/rehype-task-list'
 import { remarkAutolinkLiteral } from './plugins/remark-autolink-literal'
 import { remarkDisableConstructs } from './plugins/remark-disable-constructs'
+import { remarkIgnoreAngleBracketAutolinks } from './plugins/remark-ignore-angle-bracket-autolinks'
 import { remarkStrikethrough } from './plugins/remark-strikethrough'
 import { remarkTable } from './plugins/remark-table'
 
@@ -100,6 +101,9 @@ function createHTMLSerializer(schema: Schema): HTMLSerializerReturnType {
     // Configure the unified processor to use a custom plugin to disable constructs based on the
     // supported extensions that are enabled in the editor schema
     unifiedProcessor.use(remarkDisableConstructs, schema)
+
+    // Ignore angle-bracket autolinks because they are not a supported rich-text Markdown shortcut
+    unifiedProcessor.use(remarkIgnoreAngleBracketAutolinks)
 
     // Configure the unified processor to use a third-party plugin to turn soft line endings into
     // hard breaks (i.e. `<br>`), which will display user content closer to how it was authored

--- a/src/serializers/html/plugins/remark-ignore-angle-bracket-autolinks.ts
+++ b/src/serializers/html/plugins/remark-ignore-angle-bracket-autolinks.ts
@@ -1,0 +1,36 @@
+import { visit } from 'unist-util-visit'
+
+import type { Transformer } from 'unified'
+import type { Parent } from 'unist'
+
+/**
+ * Treats angle-bracket HTTP(S) autolinks as plain text because they are not a supported rich-text
+ * Markdown shortcut.
+ */
+function remarkIgnoreAngleBracketAutolinks(): Transformer {
+    return (tree, file) => {
+        visit(tree as Parent, (node, index, parent) => {
+            const startOffset = node.position?.start.offset
+            const endOffset = node.position?.end.offset
+
+            if (
+                node.type !== 'link' ||
+                typeof startOffset !== 'number' ||
+                typeof endOffset !== 'number' ||
+                typeof index !== 'number' ||
+                !parent
+            ) {
+                return
+            }
+
+            const source = String(file.value).slice(startOffset, endOffset)
+
+            if (/^<https?:\/\/\S+>$/i.test(source)) {
+                const textNode = { type: 'text', value: source }
+                parent.children[index] = textNode
+            }
+        })
+    }
+}
+
+export { remarkIgnoreAngleBracketAutolinks }

--- a/src/serializers/html/plugins/remark-ignore-angle-bracket-autolinks.ts
+++ b/src/serializers/html/plugins/remark-ignore-angle-bracket-autolinks.ts
@@ -1,15 +1,15 @@
 import { visit } from 'unist-util-visit'
 
+import type { Root } from 'mdast'
 import type { Transformer } from 'unified'
-import type { Parent } from 'unist'
 
 /**
  * Treats angle-bracket HTTP(S) autolinks as plain text because they are not a supported rich-text
  * Markdown shortcut.
  */
-function remarkIgnoreAngleBracketAutolinks(): Transformer {
+function remarkIgnoreAngleBracketAutolinks(): Transformer<Root> {
     return (tree, file) => {
-        visit(tree as Parent, (node, index, parent) => {
+        visit(tree, 'link', (node, index, parent) => {
             const startOffset = node.position?.start.offset
             const endOffset = node.position?.end.offset
 
@@ -26,8 +26,7 @@ function remarkIgnoreAngleBracketAutolinks(): Transformer {
             const source = String(file.value).slice(startOffset, endOffset)
 
             if (/^<https?:\/\/\S+>$/i.test(source)) {
-                const textNode = { type: 'text', value: source }
-                parent.children[index] = textNode
+                parent.children[index] = { type: 'text', value: source }
             }
         })
     }


### PR DESCRIPTION
## Overview

Treats angle-bracket HTTP(S) URLs as plain text when loading stored Markdown into rich-text editors. This prevents unsupported Markdown syntax from becoming a link whether or not the link extension is enabled.

## Reference

Related to [Doist/Issues#20812](https://github.com/Doist/Issues/issues/20812)

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
- [x] Added/updated unit test cases and/or end-to-end test cases

## Test plan

1. Open the deployed Storybook preview
2. Open the `Default` story under `Typist Editor → Rich-text`
3. Set the `content` control to `<https://duckduckgo.com>`
    - [ ] Observe that the editor displays `<https://duckduckgo.com>` as plain text rather than a link
    - [ ] Observe that `Markdown Output` contains `<https://duckduckgo.com>` unchanged

## Demo

| Before                      | After                      |
| --------------------------- | -------------------------- |
| <img width="1281" height="848" alt="image" src="https://github.com/user-attachments/assets/1f92721f-808e-4144-906e-a0a608d18a2b" /> | <img width="1281" height="848" alt="image" src="https://github.com/user-attachments/assets/97d904b5-8383-479c-8c90-74d39fc1001e" /> |