### PR TITLE
ci: include package manifest in dependency cache keys

### DIFF
--- a/.github/workflows/check-ci-validation.yml
+++ b/.github/workflows/check-ci-validation.yml
@@ -38,7 +38,7 @@ jobs:
               id: node-modules-cache
               uses: actions/cache@v5
               with:
-                  key: node-modules-cache-${{ hashFiles('**/package-lock.json', '**/.node-version') }}
+                  key: node-modules-cache-${{ hashFiles('package.json', '**/package-lock.json', '**/.node-version') }}
                   path: node_modules/
 
             - name: Install project npm dependencies
@@ -68,7 +68,7 @@ jobs:
               id: node-modules-cache
               uses: actions/cache@v5
               with:
-                  key: node-modules-cache-${{ hashFiles('**/package-lock.json', '**/.node-version') }}
+                  key: node-modules-cache-${{ hashFiles('package.json', '**/package-lock.json', '**/.node-version') }}
                   path: node_modules/
 
             - name: Install project npm dependencies
@@ -110,7 +110,7 @@ jobs:
               id: node-modules-cache
               uses: actions/cache@v5
               with:
-                  key: node-modules-cache-${{ hashFiles('**/package-lock.json', '**/.node-version') }}
+                  key: node-modules-cache-${{ hashFiles('package.json', '**/package-lock.json', '**/.node-version') }}
                   path: node_modules/
 
             - name: Install project npm dependencies
@@ -146,7 +146,7 @@ jobs:
               id: node-modules-cache
               uses: actions/cache/restore@v5
               with:
-                  key: node-modules-cache-${{ hashFiles('**/package-lock.json', '**/.node-version') }}
+                  key: node-modules-cache-${{ hashFiles('package.json', '**/package-lock.json', '**/.node-version') }}
                   path: node_modules/
 
             - name: Install project npm dependencies
@@ -190,7 +190,7 @@ jobs:
               id: node-modules-cache
               uses: actions/cache@v5
               with:
-                  key: node-modules-cache-${{ hashFiles('**/package-lock.json', '**/.node-version') }}
+                  key: node-modules-cache-${{ hashFiles('package.json', '**/package-lock.json', '**/.node-version') }}
                   path: node_modules/
 
             - name: Install project npm dependencies

--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -63,7 +63,7 @@ jobs:
               id: node-modules-cache
               uses: actions/cache@v5
               with:
-                  key: node-modules-cache-${{ hashFiles('**/package-lock.json', '**/.node-version') }}
+                  key: node-modules-cache-${{ hashFiles('package.json', '**/package-lock.json', '**/.node-version') }}
                   path: node_modules/
 
             - name: Install project npm dependencies


### PR DESCRIPTION
## 🗺 Overview

A recent Reactist dependency update introduced a peer dependency conflict. Because the update changed `package.json` without changing `package-lock.json`, CI restored cached `node_modules`, skipped `npm ci`, and passed with the previous dependency installed. A later lockfile change invalidated the cache and exposed the installation failure, blocking unrelated work.

After fixing the immediate Reactist issue, I audited other active projects for the same cache pattern. This PR adds `package.json` to the `node_modules` cache key so manifest-only changes run dependency installation and expose failures immediately.

This can cause an extra cache miss when a `package.json` change does not affect installed dependencies, but it’s a small price to pay for catching broken dependency changes before they merge and block unrelated work.

### 🔗 Reference

- https://github.com/Doist/reactist/pull/1173
