### PR TITLE
test: destroy editors after rich text list item tests

### DIFF
--- a/src/extensions/rich-text/rich-text-list-item.test.ts
+++ b/src/extensions/rich-text/rich-text-list-item.test.ts
@@ -16,6 +16,7 @@ function createEditorWithCaretAfter(content: string, text: string): Editor {
         extensions: [RichTextKit.configure({ code: false })],
         content,
     })
+    onTestFinished(() => editor.destroy())
 
     let caretPosition: number | null = null
     editor.state.doc.descendants((node, position) => {


### PR DESCRIPTION
## Overview

Destroy each Tiptap `Editor` created by `createEditorWithCaretAfter` when its test finishes. This prevents ProseMirror's DOM observer from outliving jsdom and intermittently failing the React 18 compatibility check after all assertions pass.

## Reference

- React 18 compatibility failure: https://github.com/Doist/typist/actions/runs/32711520284/job/97383825624

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
- [x] Added/updated unit test cases and/or end-to-end test cases

## Test plan

Code review and CI checks should be sufficient
