### PR TITLE
chore(deps): remove Reactist

### DIFF
--- a/.storybook/preview.style.css
+++ b/.storybook/preview.style.css
@@ -15,16 +15,14 @@
     --storybook-theme-barBg: #f6f7f3;
     --storybook-theme-barTextColor: #9ba399;
 
-    /*
-     * Overwritten Reactist CSS variables to match the Storybook theme.
-     */
-    --reactist-actionable-secondary-idle-tint: #706e67;
-    --reactist-actionable-secondary-idle-fill: #f1f0ee;
-    --reactist-actionable-secondary-hover-tint: #706e67;
-    --reactist-actionable-secondary-hover-fill: #eaeae5;
-    --reactist-actionable-quaternary-idle-tint: #706e67;
-    --reactist-actionable-quaternary-hover-fill: #eaeae5;
-    --reactist-actionable-quaternary-disabled-tint: #c6c6b8;
+    --storybook-theme-actionColor: #706e67;
+    --storybook-theme-actionBackground: #f1f0ee;
+    --storybook-theme-actionHoverBackground: #eaeae5;
+    --storybook-theme-actionDisabledColor: #c6c6b8;
+    --storybook-theme-spacingXsmall: 4px;
+    --storybook-theme-spacingSmall: 8px;
+    --storybook-theme-spacingMedium: 12px;
+    --storybook-theme-spacingLarge: 16px;
 }
 
 html {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,3 @@
-import '@doist/reactist/styles/reactist.css'
-
 import 'github-markdown-css/github-markdown-light.css'
 
 import './preview.style.css'

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
                 "unist-util-visit": "5.1.0"
             },
             "devDependencies": {
-                "@doist/reactist": "37.3.1",
                 "@mdx-js/react": "3.1.1",
                 "@semantic-release/changelog": "6.0.3",
                 "@semantic-release/exec": "7.1.0",
@@ -179,50 +178,6 @@
             "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@ariakit/core": {
-            "version": "0.4.18",
-            "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.18.tgz",
-            "integrity": "sha512-9urEa+GbZTSyredq3B/3thQjTcSZSUC68XctwCkJNH/xNfKN5O+VThiem2rcJxpsGw8sRUQenhagZi0yB4foyg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@ariakit/react": {
-            "version": "0.4.21",
-            "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.21.tgz",
-            "integrity": "sha512-UjP99Y7cWxA5seRECEE0RPZFImkLGFIWPflp65t0BVZwlMw4wp9OJZRHMrnkEkKl5KBE2NR/gbbzwHc6VNGzsA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@ariakit/react-core": "0.4.21"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/ariakit"
-            },
-            "peerDependencies": {
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@ariakit/react-core": {
-            "version": "0.4.21",
-            "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.21.tgz",
-            "integrity": "sha512-rUI9uB/gT3mROFja/ka7/JukkdljIZR3eq3BGiQqX4Ni/KBMDvPK8FvVLnC0TGzWcqNY2bbfve8QllvHzuw4fQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@ariakit/core": "0.4.18",
-                "@floating-ui/dom": "^1.0.0",
-                "use-sync-external-store": "^1.2.0"
-            },
-            "peerDependencies": {
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
         },
         "node_modules/@asamuzakjp/css-color": {
             "version": "6.0.7",
@@ -709,390 +664,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=20.19.0"
-            }
-        },
-        "node_modules/@doist/reactist": {
-            "version": "37.3.1",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-37.3.1.tgz",
-            "integrity": "sha512-RGKFrk+Vd1Ffyv4lXNaBGjFcUJjxfYeF8MsXAja5iLtifQAGwBrCucF60I6xgePPLxUGpEjpsWl1c6zNlC+YLg==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "7.29.7",
-                "aria-hidden": "1.2.6",
-                "dayjs": "1.11.23",
-                "patch-package": "8.0.1",
-                "react-focus-lock": "2.13.7",
-                "react-keyed-flatten-children": "1.3.0",
-                "react-markdown": "5.0.3",
-                "use-callback-ref": "1.3.3"
-            },
-            "engines": {
-                "node": ">=24",
-                "npm": ">=11"
-            },
-            "peerDependencies": {
-                "@ariakit/react": "~0.4.19",
-                "classnames": "^2.2.5",
-                "react": ">=18.0.0 <20.0.0",
-                "react-compiler-runtime": "^1.0.0",
-                "react-dom": ">=18.0.0 <20.0.0",
-                "react-transition-group": "^4.4.5"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/@types/mdast": {
-            "version": "3.0.15",
-            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
-            "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/@types/unist": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@doist/reactist/node_modules/bail": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-            "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/character-entities": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-            "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/character-entities-legacy": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-            "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/character-reference-invalid": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-            "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/is-alphabetical": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-            "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/is-alphanumerical": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-            "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-alphabetical": "^1.0.0",
-                "is-decimal": "^1.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/is-decimal": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-            "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/is-hexadecimal": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-            "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/is-plain-obj": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/mdast-util-from-markdown": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
-            "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/mdast": "^3.0.0",
-                "mdast-util-to-string": "^2.0.0",
-                "micromark": "~2.11.0",
-                "parse-entities": "^2.0.0",
-                "unist-util-stringify-position": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/mdast-util-to-string": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
-            "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/micromark": {
-            "version": "2.11.4",
-            "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
-            "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.0.0",
-                "parse-entities": "^2.0.0"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/parse-entities": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
-            "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "character-entities": "^1.0.0",
-                "character-entities-legacy": "^1.0.0",
-                "character-reference-invalid": "^1.0.0",
-                "is-alphanumerical": "^1.0.0",
-                "is-decimal": "^1.0.0",
-                "is-hexadecimal": "^1.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@doist/reactist/node_modules/react-markdown": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-5.0.3.tgz",
-            "integrity": "sha512-jDWOc1AvWn0WahpjW6NK64mtx6cwjM4iSsLHJPNBqoAgGOVoIdJMqaKX4++plhOtdd4JksdqzlDibgPx6B/M2w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/mdast": "^3.0.3",
-                "@types/unist": "^2.0.3",
-                "html-to-react": "^1.3.4",
-                "mdast-add-list-metadata": "1.0.1",
-                "prop-types": "^15.7.2",
-                "react-is": "^16.8.6",
-                "remark-parse": "^9.0.0",
-                "unified": "^9.0.0",
-                "unist-util-visit": "^2.0.0",
-                "xtend": "^4.0.1"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            },
-            "peerDependencies": {
-                "@types/react": ">=16",
-                "react": ">=16"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/remark-parse": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-            "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mdast-util-from-markdown": "^0.8.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/trough": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-            "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/unified": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
-            "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bail": "^1.0.0",
-                "extend": "^3.0.0",
-                "is-buffer": "^2.0.0",
-                "is-plain-obj": "^2.0.0",
-                "trough": "^1.0.0",
-                "vfile": "^4.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/unist-util-is": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-            "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/unist-util-stringify-position": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-            "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.2"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/unist-util-visit": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-            "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-is": "^4.0.0",
-                "unist-util-visit-parents": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/unist-util-visit-parents": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-            "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-is": "^4.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/vfile": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-            "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "is-buffer": "^2.0.0",
-                "unist-util-stringify-position": "^2.0.0",
-                "vfile-message": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/vfile-message": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-            "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-stringify-position": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/@emnapi/core": {
@@ -1588,37 +1159,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/@floating-ui/core": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
-            "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@floating-ui/utils": "^0.2.12"
-            }
-        },
-        "node_modules/@floating-ui/dom": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
-            "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@floating-ui/core": "^1.8.0",
-                "@floating-ui/utils": "^0.2.12"
-            }
-        },
-        "node_modules/@floating-ui/utils": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
-            "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
             "version": "0.7.0",
@@ -6342,13 +5882,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@yarnpkg/lockfile": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
-            "dev": true,
-            "license": "BSD-2-Clause"
-        },
         "node_modules/@yuku-codegen/binding-darwin-arm64": {
             "version": "0.7.3",
             "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-darwin-arm64/-/binding-darwin-arm64-0.7.3.tgz",
@@ -6772,19 +6305,6 @@
             "integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/aria-hidden": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
-            "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/aria-query": {
             "version": "5.3.0",
@@ -7260,22 +6780,6 @@
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/ci-info": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/sibiraj-s"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/classnames": {
@@ -7932,13 +7436,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/dayjs": {
-            "version": "1.11.23",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
-            "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -8101,13 +7598,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/detect-node-es": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-            "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/devlop": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -8153,90 +7643,6 @@
             "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/dom-helpers": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-            "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/runtime": "^7.8.7",
-                "csstype": "^3.0.2"
-            }
-        },
-        "node_modules/dom-serializer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
-                "entities": "^4.2.0"
-            },
-            "funding": {
-                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-            }
-        },
-        "node_modules/dom-serializer/node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/domelementtype": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fb55"
-                }
-            ],
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/domhandler": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "domelementtype": "^2.3.0"
-            },
-            "engines": {
-                "node": ">= 4"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domhandler?sponsor=1"
-            }
-        },
-        "node_modules/domutils": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "dom-serializer": "^2.0.0",
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domutils?sponsor=1"
-            }
         },
         "node_modules/dot-prop": {
             "version": "5.3.0",
@@ -8949,29 +8355,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/find-yarn-workspace-root": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "micromatch": "^4.0.2"
-            }
-        },
-        "node_modules/focus-lock": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.6.tgz",
-            "integrity": "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.3"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/for-each": {
@@ -9711,21 +9094,6 @@
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
-        "node_modules/html-to-react": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.7.0.tgz",
-            "integrity": "sha512-b5HTNaTGyOj5GGIMiWVr1k57egAZ/vGy0GGefnCQ1VW5hu9+eku8AXHtf2/DeD95cj/FKBKYa1J7SWBOX41yUQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "domhandler": "^5.0",
-                "htmlparser2": "^9.0",
-                "lodash.camelcase": "^4.3.0"
-            },
-            "peerDependencies": {
-                "react": "^0.13.0 || ^0.14.0 || >=15"
-            }
-        },
         "node_modules/html-url-attributes": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -9745,39 +9113,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/htmlparser2": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-            "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
-            "dev": true,
-            "funding": [
-                "https://github.com/fb55/htmlparser2?sponsor=1",
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fb55"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.3",
-                "domutils": "^3.1.0",
-                "entities": "^4.5.0"
-            }
-        },
-        "node_modules/htmlparser2/node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/http-proxy-agent": {
@@ -10114,30 +9449,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-buffer": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/is-callable": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -10211,22 +9522,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-extglob": {
@@ -10596,19 +9891,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/isarray": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -10773,26 +10055,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/json-stable-stringify": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
-            "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.4",
-                "isarray": "^2.0.5",
-                "jsonify": "^0.0.1",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -10824,26 +10086,6 @@
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/jsonify": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-            "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-            "dev": true,
-            "license": "Public Domain",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/klaw-sync": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.1.11"
             }
         },
         "node_modules/lefthook": {
@@ -11439,19 +10681,6 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/loose-envify": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-            },
-            "bin": {
-                "loose-envify": "cli.js"
-            }
-        },
         "node_modules/loupe": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -11681,23 +10910,6 @@
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/mdast-add-list-metadata": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz",
-            "integrity": "sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "unist-util-visit-parents": "1.1.2"
-            }
-        },
-        "node_modules/mdast-add-list-metadata/node_modules/unist-util-visit-parents": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz",
-            "integrity": "sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/mdast-util-find-and-replace": {
             "version": "3.0.2",
@@ -15098,23 +14310,6 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/open": {
-            "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^2.0.0",
-                "is-wsl": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/orderedmap": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
@@ -15561,51 +14756,6 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
-        "node_modules/patch-package": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
-            "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@yarnpkg/lockfile": "^1.1.0",
-                "chalk": "^4.1.2",
-                "ci-info": "^3.7.0",
-                "cross-spawn": "^7.0.3",
-                "find-yarn-workspace-root": "^2.0.0",
-                "fs-extra": "^10.0.0",
-                "json-stable-stringify": "^1.0.2",
-                "klaw-sync": "^6.0.0",
-                "minimist": "^1.2.6",
-                "open": "^7.4.2",
-                "semver": "^7.5.3",
-                "slash": "^2.0.0",
-                "tmp": "^0.2.4",
-                "yaml": "^2.2.2"
-            },
-            "bin": {
-                "patch-package": "index.js"
-            },
-            "engines": {
-                "node": ">=14",
-                "npm": ">5"
-            }
-        },
-        "node_modules/patch-package/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -16016,25 +15166,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/prop-types": {
-            "version": "15.8.1",
-            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.4.0",
-                "object-assign": "^4.1.1",
-                "react-is": "^16.13.1"
-            }
-        },
-        "node_modules/prop-types/node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/property-information": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -16360,30 +15491,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/react-clientside-effect": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.8.tgz",
-            "integrity": "sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.12.13"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            }
-        },
-        "node_modules/react-compiler-runtime": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-1.0.0.tgz",
-            "integrity": "sha512-rRfjYv66HlG8896yPUDONgKzG5BxZD1nV9U6rkm+7VCuvQc903C4MjcoZR4zPw53IKSOX9wMQVpA1IAbRtzQ7w==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "peerDependencies": {
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
-            }
-        },
         "node_modules/react-docgen": {
             "version": "8.0.3",
             "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.3.tgz",
@@ -16441,30 +15548,6 @@
                 "react": "^19.2.8"
             }
         },
-        "node_modules/react-focus-lock": {
-            "version": "2.13.7",
-            "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.7.tgz",
-            "integrity": "sha512-20lpZHEQrXPb+pp1tzd4ULL6DyO5D2KnR0G69tTDdydrmNhU7pdFmbQUYVyHUgp+xN29IuFR0PVuhOmvaZL9Og==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.0.0",
-                "focus-lock": "^1.3.6",
-                "prop-types": "^15.6.2",
-                "react-clientside-effect": "^1.2.7",
-                "use-callback-ref": "^1.3.3",
-                "use-sidecar": "^1.1.3"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/react-icons": {
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.7.0.tgz",
@@ -16479,26 +15562,6 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/react-keyed-flatten-children": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/react-keyed-flatten-children/-/react-keyed-flatten-children-1.3.0.tgz",
-            "integrity": "sha512-qB7A6n+NHU0x88qTZGAJw6dsqwI941jcRPBB640c/CyWqjPQQ+YUmXOuzPziuHb7iqplM3xksWAbGYwkQT0tXA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "react-is": "^16.8.6"
-            },
-            "peerDependencies": {
-                "react": ">=15.0.0"
-            }
-        },
-        "node_modules/react-keyed-flatten-children/node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -16549,24 +15612,6 @@
             },
             "peerDependencies": {
                 "react": ">= 0.14.0"
-            }
-        },
-        "node_modules/react-transition-group": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-            "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true,
-            "dependencies": {
-                "@babel/runtime": "^7.5.5",
-                "dom-helpers": "^5.0.1",
-                "loose-envify": "^1.4.0",
-                "prop-types": "^15.6.2"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0",
-                "react-dom": ">=16.6.0"
             }
         },
         "node_modules/react-use-event-hook": {
@@ -17807,16 +16852,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/slash": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -18601,16 +17636,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/tmp": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
-            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.14"
-            }
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -19256,51 +18281,6 @@
             "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            }
-        },
-        "node_modules/use-callback-ref": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-            "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/use-sidecar": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-            "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "detect-node-es": "^1.1.0",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
             }
         },
         "node_modules/use-sync-external-store": {
@@ -20251,22 +19231,6 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/yaml": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/eemeli"
-            }
         },
         "node_modules/yargs": {
             "version": "18.0.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
         "unist-util-visit": "5.1.0"
     },
     "devDependencies": {
-        "@doist/reactist": "37.3.1",
         "@mdx-js/react": "3.1.1",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/exec": "7.1.0",

--- a/stories/components/button.module.css
+++ b/stories/components/button.module.css
@@ -1,0 +1,38 @@
+.button {
+    align-items: center;
+    background-color: var(--storybook-theme-actionBackground);
+    border: 1px solid transparent;
+    border-radius: var(--storybook-theme-appBorderRadius);
+    color: var(--storybook-theme-actionColor);
+    cursor: pointer;
+    display: inline-flex;
+    font-family: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    height: 32px;
+    justify-content: center;
+    line-height: 32px;
+    max-width: 100%;
+    min-width: 68px;
+    padding: 0 var(--storybook-theme-spacingMedium);
+    text-decoration: none;
+    transition:
+        color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+        background-color 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    user-select: none;
+    white-space: nowrap;
+}
+
+.button:hover:not(:disabled),
+.button:focus-visible:not(:disabled) {
+    background-color: var(--storybook-theme-actionHoverBackground);
+}
+
+.button:active:not(:disabled) {
+    transform: scale(0.97);
+}
+
+.button:disabled {
+    color: var(--storybook-theme-actionDisabledColor);
+    cursor: not-allowed;
+}

--- a/stories/components/button.tsx
+++ b/stories/components/button.tsx
@@ -1,0 +1,11 @@
+import classNames from 'classnames'
+
+import styles from './button.module.css'
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>
+
+function Button({ className, type = 'button', ...props }: ButtonProps) {
+    return <button {...props} type={type} className={classNames(styles.button, className)} />
+}
+
+export { Button }

--- a/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-decorator.module.css
+++ b/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-decorator.module.css
@@ -1,11 +1,17 @@
 :root {
-    --reactist-content-primary: var(--storybook-theme-textColor);
     --typist-editor-decorator-default-shadow: 1px 1px 2px 0 #f3f3f1;
     --typist-editor-media-border-radius: calc(var(--storybook-theme-appBorderRadius) / 2);
 }
 
+.decorator {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
 .topContainer {
     color: var(--storybook-theme-textColor);
+    display: flex;
     flex-grow: 1;
 }
 
@@ -14,18 +20,22 @@
     pointer-events: none;
 }
 
-.topContainer > div {
+.column {
     display: flex;
     flex-direction: column;
+    flex-grow: 0;
+    height: 100%;
+    min-width: 0;
+    width: 50%;
 }
 
-.topContainer > div > h3 {
-    margin: var(--reactist-spacing-large) 0 var(--reactist-spacing-medium)
-        var(--reactist-spacing-large);
+.column > h3 {
+    margin: var(--storybook-theme-spacingLarge) 0 var(--storybook-theme-spacingMedium)
+        var(--storybook-theme-spacingLarge);
     opacity: 0.85;
 }
 
-.topContainer > :first-of-type {
+.column:first-of-type {
     border-right: 1px solid var(--storybook-theme-appBorderColor);
 }
 
@@ -37,6 +47,7 @@
     flex-direction: column;
     flex-wrap: wrap;
     flex-grow: 1;
+    margin: 0 var(--storybook-theme-spacingLarge) var(--storybook-theme-spacingLarge);
     overflow-x: hidden;
     overflow-y: auto;
 }
@@ -65,10 +76,11 @@ div + .editorContainer {
     border: solid 1px var(--storybook-theme-appBorderColor);
     border-radius: var(--storybook-theme-appBorderRadius);
     flex-grow: 1;
-    padding: var(--reactist-spacing-medium);
+    margin: 0 var(--storybook-theme-spacingLarge) var(--storybook-theme-spacingLarge);
     overflow-x: hidden;
     overflow-y: auto;
     overflow-wrap: break-word;
+    padding: var(--storybook-theme-spacingMedium);
 }
 
 .outputContainer pre {
@@ -80,13 +92,16 @@ div + .editorContainer {
 .bottomFunctionsContainer {
     background-color: var(--storybook-theme-appContentBg);
     border-top: solid 1px var(--storybook-theme-appBorderColor);
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--storybook-theme-spacingXsmall);
+    justify-content: center;
     position: sticky;
     bottom: 0;
-    padding: var(--reactist-spacing-medium);
-    gap: var(--reactist-spacing-xsmall);
+    padding: var(--storybook-theme-spacingMedium);
 }
 
-.bottomFunctionsContainer button[aria-disabled] {
+.bottomFunctionsContainer button {
     font-family: var(--storybook-theme-fontCode);
     font-weight: normal;
     font-size: 0.75rem;
@@ -101,7 +116,7 @@ div + .editorContainer {
     flex-direction: column;
     font-size: 0.875rem;
     height: 100%;
-    padding: var(--reactist-spacing-medium);
+    padding: var(--storybook-theme-spacingMedium);
     outline: none;
 }
 

--- a/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-decorator.tsx
+++ b/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-decorator.tsx
@@ -1,7 +1,5 @@
 import { forwardRef, useCallback, useMemo, useState } from 'react'
 
-import { Box, Column, Columns } from '@doist/reactist'
-
 import classNames from 'classnames'
 
 import { TypistEditorToolbar } from './typist-editor-toolbar'
@@ -74,21 +72,19 @@ const TypistEditorDecorator = forwardRef<TypistEditorRef, TypistEditorDecoratorP
         )
 
         return (
-            <Box display="flex" flexDirection="column" height="full">
-                <Columns
-                    exceptionallySetClassName={classNames(styles.topContainer, {
+            <div className={styles.decorator}>
+                <div
+                    className={classNames(styles.topContainer, {
                         [styles.topContainerUnmounted]: !editorMounted,
                     })}
                 >
-                    <Column width="1/2">
+                    <section className={styles.column}>
                         <h3>Typist Editor</h3>
                         {shouldRenderToolbar ? <TypistEditorToolbar editor={typistEditor} /> : null}
-                        <Box
+                        <div
                             className={classNames(styles.editorContainer, {
                                 [styles.editorContainerUnmounted]: !editorMounted,
                             })}
-                            marginX="large"
-                            marginBottom="large"
                         >
                             {editorMounted ? (
                                 <Story
@@ -96,30 +92,19 @@ const TypistEditorDecorator = forwardRef<TypistEditorRef, TypistEditorDecoratorP
                                     args={storyArgs}
                                 />
                             ) : null}
-                        </Box>
-                    </Column>
-                    <Column width="1/2">
+                        </div>
+                    </section>
+                    <section className={styles.column}>
                         <h3>Markdown Output</h3>
-                        <Box
-                            className={styles.outputContainer}
-                            marginX="large"
-                            marginBottom="large"
-                        >
+                        <div className={styles.outputContainer}>
                             <pre>{markdownOutput}</pre>
-                        </Box>
-                    </Column>
-                </Columns>
+                        </div>
+                    </section>
+                </div>
                 {bottomFunctions ? (
-                    <Box
-                        display="flex"
-                        justifyContent="center"
-                        flexWrap="wrap"
-                        className={styles.bottomFunctionsContainer}
-                    >
-                        {bottomFunctions}
-                    </Box>
+                    <div className={styles.bottomFunctionsContainer}>{bottomFunctions}</div>
                 ) : null}
-            </Box>
+            </div>
         )
     },
 )

--- a/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-toolbar.module.css
+++ b/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-toolbar.module.css
@@ -1,28 +1,57 @@
 .toolbarContainer {
-    box-shadow: var(--typist-editor-decorator-default-shadow);
     border: solid 1px var(--storybook-theme-appBorderColor);
     border-bottom: 0;
     border-radius: var(--storybook-theme-appBorderRadius) var(--storybook-theme-appBorderRadius) 0 0;
-    gap: var(--reactist-spacing-xsmall);
+    box-shadow: var(--typist-editor-decorator-default-shadow);
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--storybook-theme-spacingXsmall);
+    justify-content: center;
+    margin: 0 var(--storybook-theme-spacingLarge);
+    padding: var(--storybook-theme-spacingXsmall);
 }
 
-.toolbarContainer button[aria-disabled] {
+.toolbarButton {
+    align-items: center;
+    background-color: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--storybook-theme-appBorderRadius);
+    color: var(--storybook-theme-actionColor);
+    cursor: pointer;
+    display: flex;
     width: 26px;
     height: 26px;
+    justify-content: center;
+    padding: 0;
+    transition:
+        color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+        background-color 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.toolbarContainer button[aria-pressed='true'] {
-    background-color: var(--reactist-btn-hover-fill);
+.toolbarButton:hover:not(:disabled),
+.toolbarButton:focus-visible:not(:disabled),
+.toolbarButton[aria-pressed='true'] {
+    background-color: var(--storybook-theme-actionHoverBackground);
 }
 
-.toolbarContainer button[aria-disabled] > svg {
+.toolbarButton:active:not(:disabled) {
+    transform: scale(0.97);
+}
+
+.toolbarButton:disabled {
+    color: var(--storybook-theme-actionDisabledColor);
+    cursor: not-allowed;
+}
+
+.toolbarButton > svg {
     width: 16px;
     height: 16px;
+    pointer-events: none;
 }
 
 .withDividerBefore {
     position: relative;
-    margin-left: calc(var(--reactist-spacing-xsmall) * 2 + 1px);
+    margin-left: calc(var(--storybook-theme-spacingXsmall) * 2 + 1px);
 }
 
 .withDividerBefore::before {
@@ -30,7 +59,7 @@
     background-color: var(--storybook-theme-appBorderColor);
     position: absolute;
     top: 0;
-    left: calc(var(--reactist-spacing-xsmall) * -2);
+    left: calc(var(--storybook-theme-spacingXsmall) * -2);
     width: 1px;
     height: 100%;
 }

--- a/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-toolbar.tsx
+++ b/stories/typist-editor/decorators/typist-editor-decorator/typist-editor-toolbar.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useSyncExternalStore } from 'react'
 
-import { Box, IconButton } from '@doist/reactist'
-
 import {
     RiArrowGoBackLine,
     RiArrowGoForwardLine,
@@ -51,7 +49,13 @@ type ToolbarButtonConfig = ToolbarButtonProps & {
 }
 
 function ToolbarButton(props: ToolbarButtonProps) {
-    return <IconButton variant="quaternary" {...props} />
+    const { icon, ...buttonProps } = props
+
+    return (
+        <button {...buttonProps} type="button" className={styles.toolbarButton}>
+            {icon}
+        </button>
+    )
 }
 
 function TypistEditorToolbar({ editor }: TypistEditorToolbarProps) {
@@ -330,24 +334,17 @@ function TypistEditorToolbar({ editor }: TypistEditorToolbarProps) {
     ]
 
     return (
-        <Box
-            className={styles.toolbarContainer}
-            display="flex"
-            flexWrap="wrap"
-            justifyContent="center"
-            marginX="large"
-            padding="xsmall"
-        >
+        <div className={styles.toolbarContainer}>
             {buttonConfigs.map(({ withDividerBefore, ...buttonProps }) =>
                 withDividerBefore ? (
-                    <Box key={buttonProps['aria-label']} className={styles.withDividerBefore}>
+                    <div key={buttonProps['aria-label']} className={styles.withDividerBefore}>
                         <ToolbarButton {...buttonProps} />
-                    </Box>
+                    </div>
                 ) : (
                     <ToolbarButton key={buttonProps['aria-label']} {...buttonProps} />
                 ),
             )}
-        </Box>
+        </div>
     )
 }
 

--- a/stories/typist-editor/extensions/suggestions/base-suggestion-dropdown.module.css
+++ b/stories/typist-editor/extensions/suggestions/base-suggestion-dropdown.module.css
@@ -9,43 +9,78 @@
 
 .baseSuggestionDropdown {
     background-color: var(--suggestion-dropdown-background-color);
-    box-shadow: var(--typist-editor-decorator-default-shadow);
     border: solid 1px var(--storybook-theme-appBorderColor);
-    width: var(--suggestion-dropdown-width);
+    border-radius: var(--storybook-theme-appBorderRadius);
+    box-shadow: var(--typist-editor-decorator-default-shadow);
+    color: var(--storybook-theme-textColor);
     max-height: calc(
         var(--suggestion-dropdown-option-height) * var(--suggestion-dropdown-item-size) +
             var(--suggestion-dropdown-spacing) * (var(--suggestion-dropdown-item-size) + 1) + 2px
     );
-    padding: var(--suggestion-dropdown-spacing) 0;
     overflow-x: hidden;
+    overflow-y: auto;
+    padding: var(--suggestion-dropdown-spacing) 0;
+    width: var(--suggestion-dropdown-width);
 }
 
-.baseSuggestionDropdown > div {
+.status {
+    align-items: center;
+    display: flex;
+    font-size: 0.8125rem;
+    gap: var(--storybook-theme-spacingXsmall);
+    line-height: 20px;
     opacity: 0.8;
+    padding: 0 var(--storybook-theme-spacingSmall);
 }
 
-.baseSuggestionDropdown [role='option'] {
+.list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.option {
+    align-items: center;
+    border-radius: var(--storybook-theme-appBorderRadius);
+    cursor: pointer;
+    display: flex;
     min-height: var(--suggestion-dropdown-option-height);
     padding: 0 var(--suggestion-dropdown-spacing);
     margin: 0 var(--suggestion-dropdown-spacing);
     scroll-margin: var(--suggestion-dropdown-spacing) 0;
-    cursor: pointer;
 }
 
-.baseSuggestionDropdown [role='option'] + [role='option'] {
+.option + .option {
     margin-top: var(--suggestion-dropdown-spacing);
 }
 
-.baseSuggestionDropdown [role='option']:first-of-type {
+.option:first-of-type {
     scroll-margin-top: calc(
         var(--suggestion-dropdown-option-height) + var(--suggestion-dropdown-spacing)
     );
 }
 
-.baseSuggestionDropdown [role='option']:hover {
+.option:hover {
     background-color: var(--suggestion-dropdown-option-hover-background-color);
 }
 
-.baseSuggestionDropdown [role='option'][aria-selected='true'] {
+.option[aria-selected='true'] {
     background-color: var(--suggestion-dropdown-option-selected-background-color);
+}
+
+.suggestionItem {
+    align-items: center;
+    display: flex;
+    flex-wrap: nowrap;
+    gap: var(--storybook-theme-spacingSmall);
+    overflow-x: hidden;
+}
+
+.suggestionLabel {
+    font-size: 0.8125rem;
+    line-height: 20px;
+    overflow: hidden;
+    padding-right: var(--storybook-theme-spacingXsmall);
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }

--- a/stories/typist-editor/extensions/suggestions/base-suggestion-dropdown.tsx
+++ b/stories/typist-editor/extensions/suggestions/base-suggestion-dropdown.tsx
@@ -1,6 +1,6 @@
+/* oxlint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-to-interactive-role, jsx-a11y/prefer-tag-over-role */
+// The editor owns keyboard focus and delegates arrow/Enter handling to this listbox.
 import { useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react'
-
-import { Box, Inline, Text } from '@doist/reactist'
 
 import { SuggestionRendererRef } from '../../../../src'
 
@@ -36,20 +36,17 @@ function BaseSuggestionDropdownItem({
     )
 
     return (
-        <Box
-            as="li"
+        <li
             id={`suggestion-${index}`}
             role="option"
             tabIndex={-1}
             aria-selected={isSelected}
-            display="flex"
-            alignItems="center"
-            borderRadius="standard"
+            className={styles.option}
             onClick={handleClick}
             ref={handleRef}
         >
             {children}
-        </Box>
+        </li>
     )
 }
 
@@ -130,20 +127,16 @@ function BaseSuggestionDropdown<TSuggestionItem extends object>({
     )
 
     return (
-        <Box
-            borderRadius="standard"
-            overflow="auto"
+        <div
             tabIndex={-1}
             className={styles.baseSuggestionDropdown}
             style={suggestionDropdownStyle}
         >
             {areSuggestionsEmpty ? (
-                <Inline paddingX="small">
-                    <Text>No results found…</Text>
-                </Inline>
+                <div className={styles.status}>No results found…</div>
             ) : areSuggestionsLoading ? (
-                <Inline paddingX="small" space="xsmall">
-                    <svg width="20" height="20" viewBox="0 0 50 50">
+                <div className={styles.status}>
+                    <svg aria-hidden="true" width="20" height="20" viewBox="0 0 50 50">
                         <path
                             fill="currentColor"
                             d="M43.935,25.145c0-10.318-8.364-18.683-18.683-18.683c-10.318,0-18.683,8.365-18.683,18.683h4.068c0-8.071,6.543-14.615,14.615-14.615c8.072,0,14.615,6.543,14.615,14.615H43.935z"
@@ -159,15 +152,15 @@ function BaseSuggestionDropdown<TSuggestionItem extends object>({
                             />
                         </path>
                     </svg>
-                    <Text>Loading…</Text>
-                </Inline>
+                    <span>Loading…</span>
+                </div>
             ) : (
-                <Box
-                    as="ul"
-                    // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role
+                <ul
                     role="listbox"
+                    tabIndex={-1}
                     aria-multiselectable={false}
                     aria-activedescendant={`suggestion-${selectedIndex}`}
+                    className={styles.list}
                 >
                     {items.map((item, index) => (
                         <BaseSuggestionDropdownItem
@@ -180,9 +173,9 @@ function BaseSuggestionDropdown<TSuggestionItem extends object>({
                             {renderItem(item)}
                         </BaseSuggestionDropdownItem>
                     ))}
-                </Box>
+                </ul>
             )}
-        </Box>
+        </div>
     )
 }
 

--- a/stories/typist-editor/extensions/suggestions/hashtag-suggestion-dropdown.module.css
+++ b/stories/typist-editor/extensions/suggestions/hashtag-suggestion-dropdown.module.css
@@ -1,4 +1,0 @@
-.hashtagSuggestionItem {
-    flex-wrap: nowrap;
-    overflow-x: hidden;
-}

--- a/stories/typist-editor/extensions/suggestions/hashtag-suggestion-dropdown.tsx
+++ b/stories/typist-editor/extensions/suggestions/hashtag-suggestion-dropdown.tsx
@@ -1,13 +1,11 @@
 import { forwardRef } from 'react'
 import { useEvent } from 'react-use-event-hook'
 
-import { Inline, Text } from '@doist/reactist'
-
 import Avatar from 'boring-avatars'
 
 import { BaseSuggestionDropdown } from './base-suggestion-dropdown'
 
-import styles from './hashtag-suggestion-dropdown.module.css'
+import styles from './base-suggestion-dropdown.module.css'
 
 import type { SuggestionRendererProps, SuggestionRendererRef } from '../../../../src'
 import type { HashtagSuggestionItem } from '../../constants/suggestions'
@@ -20,12 +18,10 @@ function getHashtagItemKey(item: HashtagSuggestionItem) {
 
 function renderHashtagItem(item: HashtagSuggestionItem) {
     return (
-        <Inline space="small" exceptionallySetClassName={styles.hashtagSuggestionItem}>
+        <div className={styles.suggestionItem}>
             <Avatar size={20} name={item.name} variant="marble" colors={HASHTAG_AVATAR_COLORS} />
-            <Text variant="callout-2" lineClamp={1}>
-                #{item.name}
-            </Text>
-        </Inline>
+            <span className={styles.suggestionLabel}>#{item.name}</span>
+        </div>
     )
 }
 

--- a/stories/typist-editor/extensions/suggestions/mention-suggestion-dropdown.module.css
+++ b/stories/typist-editor/extensions/suggestions/mention-suggestion-dropdown.module.css
@@ -1,4 +1,0 @@
-.mentionSuggestionItem {
-    flex-wrap: nowrap;
-    overflow-x: hidden;
-}

--- a/stories/typist-editor/extensions/suggestions/mention-suggestion-dropdown.tsx
+++ b/stories/typist-editor/extensions/suggestions/mention-suggestion-dropdown.tsx
@@ -1,13 +1,11 @@
 import { forwardRef } from 'react'
 import { useEvent } from 'react-use-event-hook'
 
-import { Inline, Text } from '@doist/reactist'
-
 import Avatar from 'boring-avatars'
 
 import { BaseSuggestionDropdown } from './base-suggestion-dropdown'
 
-import styles from './mention-suggestion-dropdown.module.css'
+import styles from './base-suggestion-dropdown.module.css'
 
 import type { SuggestionRendererProps, SuggestionRendererRef } from '../../../../src'
 import type { MentionSuggestionItem } from '../../constants/suggestions'
@@ -20,12 +18,10 @@ function getMentionItemKey(item: MentionSuggestionItem) {
 
 function renderMentionItem(item: MentionSuggestionItem) {
     return (
-        <Inline space="small" exceptionallySetClassName={styles.mentionSuggestionItem}>
+        <div className={styles.suggestionItem}>
             <Avatar size={20} name={item.name} variant="bauhaus" colors={MENTION_AVATAR_COLORS} />
-            <Text variant="callout-2" lineClamp={1}>
-                {item.name}
-            </Text>
-        </Inline>
+            <span className={styles.suggestionLabel}>{item.name}</span>
+        </div>
     )
 }
 

--- a/stories/typist-editor/plain-text-functions.stories.tsx
+++ b/stories/typist-editor/plain-text-functions.stories.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useRef } from 'react'
 
-import { Button } from '@doist/reactist'
-
 import { Selection } from '@tiptap/pm/state'
 import { action } from 'storybook/actions'
 
 import preview from '../../.storybook/preview'
 import { TypistEditor, TypistEditorRef } from '../../src'
+import { Button } from '../components/button'
 
 import { DEFAULT_ARG_TYPES } from './constants/defaults'
 import { MARKDOWN_PLACEHOLDER_LONG, MARKDOWN_PLACEHOLDER_SHORT } from './constants/markdown'
@@ -63,19 +62,14 @@ export const Commands = meta.story({
                     args={context.args}
                     bottomFunctions={
                         <>
-                            <Button variant="secondary" onClick={handleCreateParagraphEndClick}>
+                            <Button onClick={handleCreateParagraphEndClick}>
                                 createParagraphEnd
                             </Button>
-                            <Button variant="secondary" onClick={handleExtendWordRangeClick}>
-                                extendWordRange
-                            </Button>
-                            <Button variant="secondary" onClick={handleInsertMarkdownContentClick}>
+                            <Button onClick={handleExtendWordRangeClick}>extendWordRange</Button>
+                            <Button onClick={handleInsertMarkdownContentClick}>
                                 insertMarkdownContent
                             </Button>
-                            <Button
-                                variant="secondary"
-                                onClick={handleInsertMarkdownContentAtClick}
-                            >
+                            <Button onClick={handleInsertMarkdownContentAtClick}>
                                 insertMarkdownContentAt
                             </Button>
                         </>
@@ -113,16 +107,9 @@ export const Helpers = meta.story({
                     args={context.args}
                     bottomFunctions={
                         <>
-                            <Button variant="secondary" onClick={handleGetEditorClick}>
-                                getEditor
-                            </Button>
-                            <Button variant="secondary" onClick={handleGetMarkdownClick}>
-                                getMarkdown
-                            </Button>
-                            <Button
-                                variant="secondary"
-                                onClick={handleGetAllNodesAttributesByTypeClick}
-                            >
+                            <Button onClick={handleGetEditorClick}>getEditor</Button>
+                            <Button onClick={handleGetMarkdownClick}>getMarkdown</Button>
+                            <Button onClick={handleGetAllNodesAttributesByTypeClick}>
                                 {"getAllNodesAttributesByType('mentionSuggestion')"}
                             </Button>
                         </>

--- a/stories/typist-editor/plain-text.stories.tsx
+++ b/stories/typist-editor/plain-text.stories.tsx
@@ -1,11 +1,10 @@
 import { useCallback, useMemo, useState } from 'react'
 
-import { Button } from '@doist/reactist'
-
 import { action } from 'storybook/actions'
 
 import preview from '../../.storybook/preview'
 import { PlainTextKit, TypistEditor } from '../../src'
+import { Button } from '../components/button'
 
 import { DEFAULT_ARG_TYPES, DEFAULT_STORY_ARGS } from './constants/defaults'
 import { TypistEditorDecorator } from './decorators/typist-editor-decorator/typist-editor-decorator'
@@ -114,7 +113,7 @@ export const EventHandlers = meta.story({
                     editorMounted={isMounted}
                     bottomFunctions={
                         <>
-                            <Button variant="secondary" onClick={toggleMounted}>
+                            <Button onClick={toggleMounted}>
                                 {isMounted ? 'Unmount editor' : 'Mount editor'}
                             </Button>
                         </>

--- a/stories/typist-editor/rich-text-functions.stories.tsx
+++ b/stories/typist-editor/rich-text-functions.stories.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useRef } from 'react'
 
-import { Button } from '@doist/reactist'
-
 import { Selection } from '@tiptap/pm/state'
 import { action } from 'storybook/actions'
 
 import preview from '../../.storybook/preview'
 import { TypistEditor, TypistEditorRef } from '../../src'
+import { Button } from '../components/button'
 
 import { DEFAULT_ARG_TYPES } from './constants/defaults'
 import { MARKDOWN_PLACEHOLDER_LONG, MARKDOWN_PLACEHOLDER_SHORT } from './constants/markdown'
@@ -64,19 +63,14 @@ export const Commands = meta.story({
                     withRichTextFeatures={true}
                     bottomFunctions={
                         <>
-                            <Button variant="secondary" onClick={handleCreateParagraphEndClick}>
+                            <Button onClick={handleCreateParagraphEndClick}>
                                 createParagraphEnd
                             </Button>
-                            <Button variant="secondary" onClick={handleExtendWordRangeClick}>
-                                extendWordRange
-                            </Button>
-                            <Button variant="secondary" onClick={handleInsertMarkdownContentClick}>
+                            <Button onClick={handleExtendWordRangeClick}>extendWordRange</Button>
+                            <Button onClick={handleInsertMarkdownContentClick}>
                                 insertMarkdownContent
                             </Button>
-                            <Button
-                                variant="secondary"
-                                onClick={handleInsertMarkdownContentAtClick}
-                            >
+                            <Button onClick={handleInsertMarkdownContentAtClick}>
                                 insertMarkdownContentAt
                             </Button>
                         </>
@@ -115,16 +109,9 @@ export const Helpers = meta.story({
                     withRichTextFeatures={true}
                     bottomFunctions={
                         <>
-                            <Button variant="secondary" onClick={handleGetEditorClick}>
-                                getEditor
-                            </Button>
-                            <Button variant="secondary" onClick={handleGetMarkdownClick}>
-                                getMarkdown
-                            </Button>
-                            <Button
-                                variant="secondary"
-                                onClick={handleGetAllNodesAttributesByTypeClick}
-                            >
+                            <Button onClick={handleGetEditorClick}>getEditor</Button>
+                            <Button onClick={handleGetMarkdownClick}>getMarkdown</Button>
+                            <Button onClick={handleGetAllNodesAttributesByTypeClick}>
                                 {"getAllNodesAttributesByType('mentionSuggestion')"}
                             </Button>
                         </>

--- a/stories/typist-editor/rich-text.stories.tsx
+++ b/stories/typist-editor/rich-text.stories.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { Button } from '@doist/reactist'
-
 import { clamp, random } from 'lodash-es'
 import { action } from 'storybook/actions'
 
 import preview from '../../.storybook/preview'
 import { RichTextKit, TypistEditor } from '../../src'
+import { Button } from '../components/button'
 
 import {
     DEFAULT_ARG_TYPES,
@@ -260,7 +259,7 @@ export const EventHandlers = meta.story({
                     editorMounted={isMounted}
                     bottomFunctions={
                         <>
-                            <Button variant="secondary" onClick={toggleMounted}>
+                            <Button onClick={toggleMounted}>
                                 {isMounted ? 'Unmount editor' : 'Mount editor'}
                             </Button>
                         </>

--- a/stories/typist-editor/wrappers/rich-text-image-wrapper.tsx
+++ b/stories/typist-editor/wrappers/rich-text-image-wrapper.tsx
@@ -1,7 +1,5 @@
 import { useMemo } from 'react'
 
-import { Box } from '@doist/reactist'
-
 import classNames from 'classnames'
 
 import { NodeViewWrapper } from '../../../src'
@@ -38,7 +36,7 @@ function RichTextImageWrapper({ extension, node }: NodeViewProps) {
         <NodeViewWrapper data-drag-handle="true" className={styles.richTextImageWrapper}>
             <img {...imageAttributes} className={imageClasses} alt={alt} title={title} src={src} />
             {isAttachmentUploading ? (
-                <Box className={styles.progressOverlay} style={progressOverlayStyle} />
+                <div className={styles.progressOverlay} style={progressOverlayStyle} />
             ) : null}
         </NodeViewWrapper>
     )


### PR DESCRIPTION
## Overview

Removes the `@doist/reactist` dependency.

Replaces the Storybook-only Reactist usage with native HTML, a small local button component, and scoped CSS that preserves the existing layout, spacing, colors, and interaction states.

## PR Checklist

- [x] Pull request title follows the [Conventional Commits Specification](https://www.conventionalcommits.org/)
- [x] Added/updated unit test cases and/or end-to-end test cases
- [x] Added/updated documentation to Storybook or `README.md`

## Test plan

- [ ] Play with the [rich-text editor stories](https://deploy-preview-1497--doist-typist.netlify.app/?path=/story/typist-editor-rich-text) and spot no UI problems